### PR TITLE
fix: omit PR line when not provided

### DIFF
--- a/scripts/templates/issue-close/bugfix.md.j2
+++ b/scripts/templates/issue-close/bugfix.md.j2
@@ -3,7 +3,7 @@
 Issue: #{{ issue_number }}{% if issue_title %} — {{ issue_title }}{% endif %}
 {% if issue_url %}{{ issue_url }}{% endif %}
 
-Delivered in PR #{{ pr_number }}: {{ pr_url }}{% if merge_commit %} (merge commit `{{ merge_commit }}`){% endif %}
+{% if pr_number and pr_url %}Delivered in PR #{{ pr_number }}: {{ pr_url }}{% elif pr_url %}Delivered in PR: {{ pr_url }}{% endif %}{% if merge_commit %} (merge commit `{{ merge_commit }}`){% endif %}
 
 ## Problem
 {{ problem | default("- (short description of the bug as reported)") }}

--- a/scripts/templates/issue-close/docs.md.j2
+++ b/scripts/templates/issue-close/docs.md.j2
@@ -3,7 +3,7 @@
 Issue: #{{ issue_number }}{% if issue_title %} — {{ issue_title }}{% endif %}
 {% if issue_url %}{{ issue_url }}{% endif %}
 
-Delivered in PR #{{ pr_number }}: {{ pr_url }}{% if merge_commit %} (merge commit `{{ merge_commit }}`){% endif %}
+{% if pr_number and pr_url %}Delivered in PR #{{ pr_number }}: {{ pr_url }}{% elif pr_url %}Delivered in PR: {{ pr_url }}{% endif %}{% if merge_commit %} (merge commit `{{ merge_commit }}`){% endif %}
 
 ## Documentation Summary
 {{ summary | default("- (what was added/updated and where)") }}

--- a/scripts/templates/issue-close/feature.md.j2
+++ b/scripts/templates/issue-close/feature.md.j2
@@ -3,7 +3,7 @@
 Issue: #{{ issue_number }}{% if issue_title %} — {{ issue_title }}{% endif %}
 {% if issue_url %}{{ issue_url }}{% endif %}
 
-Delivered in PR #{{ pr_number }}: {{ pr_url }}{% if merge_commit %} (merge commit `{{ merge_commit }}`){% endif %}
+{% if pr_number and pr_url %}Delivered in PR #{{ pr_number }}: {{ pr_url }}{% if merge_commit %} (merge commit `{{ merge_commit }}`){% endif %}{% endif %}
 
 ## Feature Summary
 {{ summary | default("- (describe what users can do now)") }}

--- a/scripts/templates/issue-close/infrastructure.md.j2
+++ b/scripts/templates/issue-close/infrastructure.md.j2
@@ -3,7 +3,7 @@
 Issue: #{{ issue_number }}{% if issue_title %} — {{ issue_title }}{% endif %}
 {% if issue_url %}{{ issue_url }}{% endif %}
 
-Delivered in PR #{{ pr_number }}: {{ pr_url }}{% if merge_commit %} (merge commit `{{ merge_commit }}`){% endif %}
+{% if pr_number and pr_url %}Delivered in PR #{{ pr_number }}: {{ pr_url }}{% elif pr_url %}Delivered in PR: {{ pr_url }}{% endif %}{% if merge_commit %} (merge commit `{{ merge_commit }}`){% endif %}
 
 ## Summary
 {{ summary | default("- (what infrastructure/tooling was added/changed)") }}


### PR DESCRIPTION
## Goal / Context
Avoid confusing close comments like `Delivered in PR #:` when `./scripts/close-issue.sh` is used without `--pr` (still valid for cases where a PR isn’t available).

## Acceptance Criteria
- [x] `feature`, `bugfix`, `docs`, and `infrastructure` issue-close templates omit the PR line when `pr_number`/`pr_url` is missing.

## Validation Evidence
- [x] Ran: `./scripts/close-issue.sh --dry-run --issue 42 --template feature --data /tmp/close-issue-no-pr.json` (no PR line rendered)
- [x] Ran: `./scripts/close-issue.sh --dry-run --issue 42 --template infrastructure --data /tmp/close-issue-infra-no-pr.json` (no PR line rendered)

## Repo Hygiene / Safety
- [x] Template-only change under `scripts/templates/issue-close/`.
- [x] No changes under `projectDocs/` and no `configs/llm.json` added/modified.
