### PR TITLE
feat: close-issue placeholder quality guard

### DIFF
--- a/.github/agents/close-issue.agent.md
+++ b/.github/agents/close-issue.agent.md
@@ -21,8 +21,8 @@ Your job is to package an already-decided outcome (completed / not planned / dup
 
 - Issue number.
 - Evidence for the outcome:
-   - Completed: merged PR number (preferred) and/or merge commit SHA.
-   - Not planned / duplicate / cannot reproduce: short justification and any links to canonical issue/PR.
+  - Completed: merged PR number (preferred) and/or merge commit SHA.
+  - Not planned / duplicate / cannot reproduce: short justification and any links to canonical issue/PR.
 
 ## Hard Rules
 
@@ -60,10 +60,12 @@ If uncertain, use generic.
 ## Close Reasons (GitHub)
 
 GitHub only supports two close reasons:
+
 - completed
 - not_planned
 
 Use them like this:
+
 - completed: the work was delivered (usually by a merged PR)
 - not_planned: duplicate, won’t fix, cannot reproduce, obsolete, or rejected
 
@@ -79,6 +81,8 @@ For duplicates/cannot reproduce, include a clear explanation and link to the can
 5. Prepare a small JSON payload with the concrete details (summary, validation, notes).
 6. Run the script with `--dry-run` first to review the rendered message.
 7. Close the issue with the final rendered message.
+
+Note: `./scripts/close-issue.sh` includes a quality guard that fails if the rendered message still contains placeholder template text. You can bypass it with `--allow-placeholders` (not recommended).
 
 ## Quality Bar for the Closing Comment
 


### PR DESCRIPTION
## Goal / Context
Prevent accidentally closing issues with placeholder-filled template text (e.g. `- (add summary...)`). This enforces the same “no placeholders” quality bar we apply elsewhere (PR review gates).

## Acceptance Criteria
- [x] `./scripts/close-issue.sh` fails if the rendered message contains known placeholder/default template strings.
- [x] Users can intentionally bypass the guard with `--allow-placeholders`.
- [x] The `close-issue` agent guidance mentions the guard.

## Validation Evidence
- [x] Ran: `./scripts/close-issue.sh --dry-run --issue 42 --template feature` → exits non-zero with a placeholder list.
- [x] Ran: `./scripts/close-issue.sh --dry-run --issue 42 --template feature --data /tmp/close-filled.json` → exits 0 and renders a non-placeholder message.

## Repo Hygiene / Safety
- [x] No changes under `projectDocs/` and no `configs/llm.json` added/modified.
- [x] Guard is local-only (Bash + grep) and does not print secrets.
