### PR TITLE
chore(pr-merge): PR-first workflow + next-pr

### DIFF
--- a/.github/agents/pr-merge.agent.md
+++ b/.github/agents/pr-merge.agent.md
@@ -19,7 +19,7 @@ Provide (in order of preference):
 
 1. PR URL, or
 2. PR number + repo name (`AI-Agent-Framework` or `AI-Agent-Framework-Client`), or
-3. Issue number (if PR title contains `#<issue>`).
+3. Issue number (only if you explicitly want issue → PR lookup).
 
 Optional:
 
@@ -36,7 +36,7 @@ You are done only when all are true:
 - All required CI checks are **passing**.
 - Issue is **closed** (or if already closed by GitHub auto-close, a final comprehensive closing comment is posted).
 - Completion is **recorded** in the learning system when `actual_hours` is provided.
-- You provide a short final summary including: PR, merge SHA, issue number, metrics, and next suggested command (`./next-issue`).
+- You provide a short final summary including: PR, merge SHA, issue number (if applicable), metrics, and next suggested command (`./next-pr`).
 
 ## Hard Constraints / Guardrails
 
@@ -62,7 +62,9 @@ Determine the target repo from the PR URL or by querying with `gh pr view`.
 
 ### A2) Validate PR + CI + Template Gate
 
-Use `./scripts/prmerge <issue_number> [actual_hours]`.
+Prefer `./scripts/prmerge <issue_number> [actual_hours]` when you have an issue number and the PR title includes it.
+
+If you don't have an issue number, first discover a mergeable PR via `./next-pr`, then proceed using `gh pr view` / `gh pr checks` and `gh pr merge` as appropriate.
 
 This script already:
 

--- a/next-pr
+++ b/next-pr
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+exec ./scripts/next-pr.py "$@"

--- a/scripts/next-pr.py
+++ b/scripts/next-pr.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Recommend the next PR to merge (PR-first workflow).
+
+This helper scans open PRs across:
+- blecx/AI-Agent-Framework (backend)
+- blecx/AI-Agent-Framework-Client (client)
+
+It ranks PRs by merge readiness (CI success, mergeable, clean merge state, not draft)
+so the pr-merge workflow can stay PR-focused.
+
+Usage:
+  ./scripts/next-pr.py
+  ./scripts/next-pr.py --repo backend|client|both
+  ./scripts/next-pr.py --limit 20
+  ./scripts/next-pr.py --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Literal
+
+
+RepoKey = Literal["backend", "client"]
+
+
+REPOS: dict[RepoKey, str] = {
+    "backend": "blecx/AI-Agent-Framework",
+    "client": "blecx/AI-Agent-Framework-Client",
+}
+
+
+@dataclass(frozen=True)
+class PrCandidate:
+    repo_key: RepoKey
+    repo: str
+    number: int
+    title: str
+    url: str
+    head_ref: str
+    updated_at: str
+    is_draft: bool
+    mergeable: str
+    merge_state_status: str
+    review_decision: str
+    checks_summary: dict[str, Any]
+    score: int
+
+
+def _run_gh_json(args: list[str]) -> Any:
+    cmd = ["gh", *args]
+    try:
+        out = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(e.output.decode("utf-8", errors="replace")) from e
+
+    raw = out.decode("utf-8", errors="replace").strip()
+    if not raw:
+        return None
+    return json.loads(raw)
+
+
+def _parse_iso(ts: str) -> datetime:
+    # GitHub returns ISO8601 like 2026-01-25T21:16:23Z
+    return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+
+def _summarize_checks(status_rollup: list[dict[str, Any]] | None) -> dict[str, Any]:
+    items = status_rollup or []
+    conclusions: list[str] = []
+    pending = 0
+    for it in items:
+        concl = it.get("conclusion")
+        if concl is None:
+            pending += 1
+        else:
+            conclusions.append(str(concl).upper())
+
+    uniq = sorted(set(conclusions))
+    has_failure = any(c in {"FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED"} for c in uniq)
+    has_success = "SUCCESS" in uniq
+
+    all_success = (len(uniq) == 1 and uniq[0] == "SUCCESS" and pending == 0)
+
+    return {
+        "conclusions": uniq,
+        "pending": pending,
+        "all_success": all_success,
+        "has_failure": has_failure,
+        "has_success": has_success,
+        "count": len(items),
+    }
+
+
+def _score_pr(*, is_draft: bool, mergeable: str, merge_state_status: str, checks: dict[str, Any], review_decision: str) -> int:
+    score = 0
+
+    if is_draft:
+        score -= 20
+    else:
+        score += 5
+
+    if mergeable.upper() == "MERGEABLE":
+        score += 5
+    elif mergeable.upper() == "CONFLICTING":
+        score -= 10
+    else:
+        score -= 2
+
+    mss = merge_state_status.upper()
+    if mss == "CLEAN":
+        score += 8
+    elif mss == "UNSTABLE":
+        score += 1
+    elif mss in {"BLOCKED", "DIRTY"}:
+        score -= 5
+
+    if checks.get("all_success"):
+        score += 15
+    elif checks.get("has_failure"):
+        score -= 15
+    else:
+        # Pending/unknown
+        score += 0
+
+    rd = (review_decision or "").upper()
+    if rd == "APPROVED":
+        score += 3
+    elif rd == "CHANGES_REQUESTED":
+        score -= 3
+
+    return score
+
+
+def _fetch_open_prs(repo: str, limit: int) -> list[dict[str, Any]]:
+    return _run_gh_json(
+        [
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            str(limit),
+            "--json",
+            "number,title,url,updatedAt,isDraft,headRefName",
+        ]
+    )
+
+
+def _fetch_pr_details(repo: str, number: int) -> dict[str, Any]:
+    return _run_gh_json(
+        [
+            "pr",
+            "view",
+            str(number),
+            "--repo",
+            repo,
+            "--json",
+            "mergeable,mergeStateStatus,statusCheckRollup,reviewDecision",
+        ]
+    )
+
+
+def recommend(repo_filter: Literal["backend", "client", "both"], limit: int) -> list[PrCandidate]:
+    repo_keys: list[RepoKey]
+    if repo_filter == "both":
+        repo_keys = ["client", "backend"]
+    else:
+        repo_keys = [repo_filter]
+
+    candidates: list[PrCandidate] = []
+
+    for repo_key in repo_keys:
+        repo = REPOS[repo_key]
+        prs = _fetch_open_prs(repo, limit)
+        for pr in prs:
+            number = int(pr["number"])
+            details = _fetch_pr_details(repo, number)
+            checks = _summarize_checks(details.get("statusCheckRollup"))
+            score = _score_pr(
+                is_draft=bool(pr.get("isDraft")),
+                mergeable=str(details.get("mergeable") or ""),
+                merge_state_status=str(details.get("mergeStateStatus") or ""),
+                checks=checks,
+                review_decision=str(details.get("reviewDecision") or ""),
+            )
+            candidates.append(
+                PrCandidate(
+                    repo_key=repo_key,
+                    repo=repo,
+                    number=number,
+                    title=str(pr.get("title") or ""),
+                    url=str(pr.get("url") or ""),
+                    head_ref=str(pr.get("headRefName") or ""),
+                    updated_at=str(pr.get("updatedAt") or ""),
+                    is_draft=bool(pr.get("isDraft")),
+                    mergeable=str(details.get("mergeable") or ""),
+                    merge_state_status=str(details.get("mergeStateStatus") or ""),
+                    review_decision=str(details.get("reviewDecision") or ""),
+                    checks_summary=checks,
+                    score=score,
+                )
+            )
+
+    candidates.sort(key=lambda c: (c.score, _parse_iso(c.updated_at)), reverse=True)
+    return candidates
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Recommend the next PR to merge (PR-first)")
+    parser.add_argument("--repo", choices=["backend", "client", "both"], default="both")
+    parser.add_argument("--limit", type=int, default=20)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    try:
+        candidates = recommend(args.repo, args.limit)
+    except RuntimeError as e:
+        print("ERROR: failed to query GitHub via gh CLI", file=sys.stderr)
+        print(str(e).strip(), file=sys.stderr)
+        return 2
+
+    if args.json:
+        payload = [
+            {
+                "repo": c.repo,
+                "repo_key": c.repo_key,
+                "number": c.number,
+                "title": c.title,
+                "url": c.url,
+                "head_ref": c.head_ref,
+                "updated_at": c.updated_at,
+                "is_draft": c.is_draft,
+                "mergeable": c.mergeable,
+                "merge_state_status": c.merge_state_status,
+                "review_decision": c.review_decision,
+                "checks": c.checks_summary,
+                "score": c.score,
+            }
+            for c in candidates
+        ]
+        print(json.dumps({"recommended": payload[:1], "candidates": payload}, indent=2))
+        return 0
+
+    print("================================================================================")
+    print("NEXT PR RECOMMENDATION")
+    print("================================================================================")
+
+    if not candidates:
+        print("No open PRs found.")
+        return 0
+
+    top = candidates[0]
+    print(f"Selected PR: #{top.number} ({top.repo})")
+    print(f"Title: {top.title}")
+    print(f"URL: {top.url}")
+    print(f"Draft: {top.is_draft}")
+    print(f"Mergeable: {top.mergeable} | Merge state: {top.merge_state_status}")
+    print(
+        f"Checks: {top.checks_summary.get('conclusions')}"
+        f" (pending={top.checks_summary.get('pending')}, all_success={top.checks_summary.get('all_success')})"
+    )
+    print(f"Score: {top.score}")
+    print("--------------------------------------------------------------------------------")
+    print("Top candidates:")
+
+    for c in candidates[: min(10, len(candidates))]:
+        checks = c.checks_summary
+        concl = ",".join(checks.get("conclusions") or []) or "(none)"
+        pending = checks.get("pending")
+        print(
+            f"- {c.repo_key:7} #{c.number:<4} score={c.score:<3} mss={c.merge_state_status:<9} "
+            f"mergeable={c.mergeable:<11} draft={str(c.is_draft):<5} checks={concl} pending={pending}"
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/prmerge
+++ b/scripts/prmerge
@@ -252,7 +252,7 @@ See PR #$pr_number for complete implementation details and file-by-file changes.
 
 ## Next Steps
 
-Run \`./next-issue\` to select the next issue to work on.
+Run \`./next-pr\` to find the next mergeable PR.
 
 ---
 
@@ -311,7 +311,7 @@ See PR #$pr_number for complete details and file-by-file changes.
 
 ## Next Steps
 
-Run \`./next-issue\` to select the next issue to work on.
+Run \`./next-pr\` to find the next mergeable PR.
 
 ---
 
@@ -527,7 +527,7 @@ if [ "$PR_STATE" = "MERGED" ]; then
             warning "Completion time not recorded. Run: ./scripts/record-completion.py $ISSUE_NUMBER <hours> '<notes>'"
         fi
         
-        info "Run './next-issue' to select next issue"
+        info "Run './next-pr' to find the next mergeable PR"
         exit 0
     else
         warning "Issue #$ISSUE_NUMBER is still open. Proceeding to close..."
@@ -868,20 +868,20 @@ if [ "$ISSUE_NUMBER" = "25" ] || [ "$ISSUE_TYPE" = "infrastructure" ]; then
 fi
 
 echo "Next steps:"
-echo "  1. Run './next-issue' to select next issue"
-echo "  2. Review unblocked dependencies"
-echo "  3. Continue Step 1 implementation"
+echo "  1. Run './next-pr' to find the next mergeable PR"
+echo "  2. Review PR diffs + CI evidence"
+echo "  3. Merge (squash) when ready"
 echo ""
 
-# Offer to run next-issue
-read -p "Run './next-issue' now? (Y/n): " run_next_issue
-if [[ ! "$run_next_issue" =~ ^[Nn]$ ]]; then
+# Offer to run next-pr
+read -p "Run './next-pr' now? (Y/n): " run_next_pr
+if [[ ! "$run_next_pr" =~ ^[Nn]$ ]]; then
     echo ""
-    if [ -f "./scripts/next-issue.py" ]; then
-        ./scripts/next-issue.py
+    if [ -f "./scripts/next-pr.py" ]; then
+        ./scripts/next-pr.py
     else
-        warning "next-issue.py not found"
-        info "Please run manually: cd $MAIN_REPO && ./scripts/next-issue.py"
+        warning "next-pr.py not found"
+        info "Please run manually: cd $MAIN_REPO && ./scripts/next-pr.py"
     fi
 fi
 


### PR DESCRIPTION
## Goal / Context

Make the pr-merge workflow PR-first (not issue-first) by:
- Removing `next-issue` guidance from the prmerge flow
- Adding a `next-pr` helper that recommends the next mergeable PR across backend + client

## Acceptance Criteria

- [x] pr-merge guidance no longer instructs selecting issues (`next-issue`)
- [x] `scripts/prmerge` suggests PR discovery via `./next-pr` instead of issue selection
- [x] `./next-pr` exists and can list/recommend open PRs across both repos

## Validation Evidence

- [x] `python3 -m compileall scripts` (includes `scripts/next-pr.py`)
- [x] `./next-pr --json` runs successfully (returns empty when there are no open PRs)

## Repo Hygiene / Safety

- [x] No `projectDocs/` tracked
- [x] No `configs/llm.json` tracked
- [x] No secrets added
