### PR TITLE
docs: Add explicit issue selection order to copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -45,6 +45,44 @@ ISO 21500 Project Management AI Agent - Full-stack app with FastAPI (Python 3.10
    - Ensure PR title is clear (becomes squash commit message)
    - Delete branch after merge
 
+### Issue Selection Order (resolve-issue-dev)
+
+**When selecting the next issue to work on, ALWAYS follow this priority order:**
+
+1. **Priority 1: Backend/TUI/CLI issues**
+   - Repository: `blecx/AI-Agent-Framework`
+   - Includes: API services, domain models, CLI tools, backend tests
+   - Example issue numbers: #69-#78 (Step 2 backend)
+
+2. **Priority 2: Client/UX issues**
+   - Repository: `blecx/AI-Agent-Framework-Client`
+   - Includes: React components, UI features, client tests
+   - Example issue numbers: #102-#109 (Step 2 frontend)
+
+3. **Within each priority group:**
+   - **Select the LOWEST issue number first**
+   - Work sequentially: #69 → #70 → #71 → ... → #77 → #78
+   - Then move to client: #102 → #103 → ... → #109
+
+**Rationale:**
+
+- **Dependency management:** Frontend depends on backend APIs
+- **Parallel work:** Backend team completes work while frontend team prepares
+- **Predictability:** Everyone knows "what's next" in implementation order
+- **Quality gates:** Backend E2E tests validate before frontend development
+
+**Example (Step 2):**
+
+- Open issues: #69, #70, #72, #102, #104
+- **Correct order:** #69 → #70 → #72 → #102 → #104
+- **Why:** Work backend issues (#69, #70, #72) before client issues (#102, #104)
+
+**Edge cases:**
+
+- If all backend issues are complete, start client issues (lowest number first)
+- If all issues in both repos are complete, check for new issues or declare milestone done
+- If backend issue is blocked, skip to next backend issue (don't jump to client)
+
 ### Domain-Driven Design (DDD) Architecture (REQUIRED)
 
 **All code changes must follow DDD architecture patterns:**


### PR DESCRIPTION
# Summary

Add **explicit issue selection order** to copilot instructions for resolve-issue-dev mode: always select lowest available issue number, prioritizing backend/TUI/CLI issues before client issues.

## Goal / Context

**Goal:** Enforce consistent, predictable issue selection order that respects dependencies (backend APIs before frontend consumers).

**Context:** resolve-issue-dev mode previously didn't specify explicit issue selection order. This could lead to:
- Frontend work starting before backend APIs are ready
- Confusion about "what to work on next"
- Unpredictable implementation order
- Blocked work waiting on dependencies

**Value:** Developers and agents now have clear priority order, ensuring sequential implementation that respects dependencies.

## Acceptance Criteria

- [x] Issue selection order documented in `.github/copilot-instructions.md`
- [x] Backend-first priority explicitly stated (backend/TUI/CLI → client)
- [x] "Lowest number first" rule clearly documented
- [x] Examples provided for Step 2 context (#69-#78 → #102-#109)
- [x] Rationale explained (dependency management, predictability)
- [x] Edge cases handled (all backend complete, blocked issues)

## Validation Evidence

- [x] New section added: "Issue Selection Order (resolve-issue-dev)"
- [x] Priority order documented: Backend (Priority 1) → Client (Priority 2)
- [x] Sequential selection within groups: lowest number first
- [x] Example provided: #69, #70, #72, #102, #104 → work order: #69 → #70 → #72 → #102 → #104
- [x] Edge cases documented (all backend complete, blocked issues)
- [x] No code changes (documentation only)

## Repo Hygiene / Safety

- [x] No projectDocs/ committed
- [x] No configs/llm.json committed
- [x] No code changes to apps/api/ or apps/web/
- [x] Commit follows conventional commits format
- [x] Branch pushed and up to date
- [x] No merge conflicts

---

## Issue / Tracking Link

Fixes: #83

## How to review

1. **Read new section** in [.github/copilot-instructions.md](.github/copilot-instructions.md):
   - Find "Issue Selection Order (resolve-issue-dev)" section
   - Verify priority order: Backend/TUI/CLI first, then Client
   - Check "lowest number first" rule is clear

2. **Validate examples**:
   - Example shows correct order for Step 2: #69 → #70 → #72 → #102 → #104
   - Rationale explains why (dependency management)

3. **Check edge cases**:
   - All backend complete → start client
   - Blocked backend issue → skip to next backend
   - All issues complete → check for new or declare done

4. **Verify placement**:
   - Section appears after "Merge Strategy"
   - Before "Domain-Driven Design (DDD) Architecture"
   - Logically grouped with workflow documentation

## Cross-repo / Downstream impact

**Related repositories:**
- **blecx/AI-Agent-Framework:** Backend issues prioritized first
- **blecx/AI-Agent-Framework-Client:** Client issues worked after backend

**Impact:**
- ✅ No code changes - documentation only
- ✅ Clarifies intended workflow for resolve-issue-dev mode
- ✅ Prevents confusion about issue selection
- ✅ Ensures dependencies respected (backend before frontend)

**Coordination:**
- Frontend developers can plan knowing backend work completes first
- Issue assignment can follow documented priority order
- Agents using resolve-issue-dev mode have clear selection algorithm

## Additional Context

**What changed:**
- Added 38 lines to `.github/copilot-instructions.md`
- New section: "Issue Selection Order (resolve-issue-dev)"
- Documents priority order, sequential selection, rationale, examples, edge cases

**Why it matters:**
Step 2 has 18 issues split across backend (#69-#78) and client (#102-#109). Without explicit order:
- Risk of starting #102 (frontend) before #69-#77 (backend APIs) are ready
- Confusion about which issue to tackle next
- Potential for blocked work

With explicit order:
- Clear progression: #69 → #70 → ... → #78 → #102 → ... → #109
- Backend APIs validated (E2E tests #78) before frontend starts
- Predictable timeline: backend Phase 1 (3 weeks) → frontend Phase 2 (3 weeks)

**Related documentation:**
- `.github/copilot-instructions.md` - Development workflow (updated here)
- `planning/STEP-2-REQUIREMENTS.md` - Implementation phases (backend → frontend)
- `planning/step-2-complete-status.md` - Concurrency analysis

**Review estimate:** 5-10 minutes  
**Merge strategy:** Squash merge
