### PR TITLE
docs: add comprehensive docstrings to template domain validators (Issue #111)

### DIFF
--- a/apps/api/domain/templates/models.py
+++ b/apps/api/domain/templates/models.py
@@ -25,7 +25,18 @@ class Template(BaseModel):
     @field_validator("artifact_type")
     @classmethod
     def validate_artifact_type(cls, v: str) -> str:
-        """Validate artifact_type is one of allowed values."""
+        """
+        Validate artifact_type is one of allowed values.
+
+        Args:
+            v: The artifact_type value to validate
+
+        Returns:
+            The validated artifact_type
+
+        Raises:
+            ValueError: If artifact_type not in allowed set
+        """
         allowed_types = {"pmp", "raid", "blueprint", "proposal", "report"}
         if v not in allowed_types:
             raise ValueError(f"artifact_type must be one of {allowed_types}, got '{v}'")
@@ -34,7 +45,18 @@ class Template(BaseModel):
     @field_validator("schema")
     @classmethod
     def validate_schema_structure(cls, v: Dict[str, Any]) -> Dict[str, Any]:
-        """Validate schema has basic JSON Schema structure."""
+        """
+        Validate schema has basic JSON Schema structure.
+
+        Args:
+            v: The schema dictionary to validate
+
+        Returns:
+            The validated schema dictionary
+
+        Raises:
+            ValueError: If schema is not a dict or missing 'type' field
+        """
         if not isinstance(v, dict):
             raise ValueError("schema must be a dictionary")
         if "type" not in v:


### PR DESCRIPTION
## Goal / Context

Achieve 100% docstring coverage in domain validators by documenting all validator methods (Issue #111).

**Key changes:**
- ✅ Added comprehensive docstrings to validate_artifact_type (@field_validator)
- ✅ Added comprehensive docstrings to validate_schema_structure (@field_validator)
- ✅ Followed Google docstring style (Args, Returns, Raises sections)
- ✅ 100% backward compatibility - all 537 tests pass
- ✅ No functional changes - only improved documentation

## Acceptance Criteria

- [x] All validators have docstrings
- [x] Docstrings follow Google style
- [x] Include Args, Returns, Raises sections
- [x] 100% coverage in domain layer

## Issue / Tracking Link (required)

Fixes: #111

## Validation Evidence

### Automated checks

- [x] Lint passes
  - Command(s): `python -m black apps/api/ && python -m flake8 apps/api/`
  - Evidence: `1 file reformatted, 68 files left unchanged` (Black), `0 errors` (flake8)

- [x] Build passes
  - Command(s): No build required for Python backend
  - Evidence: All imports resolved, no syntax errors

- [x] Tests pass (pytest)
  - Command(s): `pytest -q --tb=short`
  - Evidence: `537 passed, 6 skipped, 18 warnings in 68.84s`

### Manual test evidence (required)

**Docstring verification:**
```bash
# Updated validator docstrings in templates/models.py
$ git diff apps/api/domain/templates/models.py --stat
apps/api/domain/templates/models.py | 26 ++++++++++++++++++++++++--
1 file changed, 24 insertions(+), 2 deletions(-)

# Example docstring added (validate_artifact_type):
"""
Validate artifact_type is one of allowed values.

Args:
    v: The artifact_type value to validate
    
Returns:
    The validated artifact_type
    
Raises:
    ValueError: If artifact_type not in allowed set
"""
```

## Repo Hygiene / Safety

- [x] No projectDocs/ committed
  - Command: `git diff --name-only origin/main | grep projectDocs || echo "None"`
  - Evidence: None

- [x] No configs/llm.json committed
  - Command: `git diff --name-only origin/main | grep configs/llm.json || echo "None"`
  - Evidence: None

- [x] All changes scoped to issue
  - Evidence: 1 file changed (24 insertions, 2 deletions): apps/api/domain/templates/models.py

- [x] Backward compatibility maintained
  - Evidence: No logic changes, only added docstrings (documentation-only change)

## How to review

1. **Check docstring format** - Verify both validators follow Google style with Args, Returns, Raises
2. **Verify completeness** - Confirm all @field_validator methods in templates/models.py are documented
3. **Test unchanged behavior** - Run `pytest tests/integration/test_template_service.py` to verify validators work identically
4. **Style consistency** - Compare with existing docstrings in templates/validators.py

## Cross-repo / Downstream impact (always include)

**Impact: None** - Documentation-only change, no API or behavioral modifications
