### PR TITLE
fix(prmerge): define helper functions before first use

### DIFF
--- a/scripts/prmerge
+++ b/scripts/prmerge
@@ -23,6 +23,38 @@
 
 set -e
 
+# Color codes for output (must be defined before helper functions use them)
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Helper functions (must be defined before first use)
+info() {
+    echo -e "${BLUE}ℹ${NC} $1"
+}
+
+success() {
+    echo -e "${GREEN}✅${NC} $1"
+}
+
+warning() {
+    echo -e "${YELLOW}⚠️${NC} $1"
+}
+
+error() {
+    echo -e "${RED}❌${NC} $1"
+}
+
+section() {
+    echo ""
+    echo "========================================="
+    echo "$1"
+    echo "========================================="
+    echo ""
+}
+
 # Detect repository context
 detect_repo() {
     local current_dir="$(pwd)"
@@ -81,38 +113,6 @@ REPO_NAME=$(get_repo_name "$REPO_TYPE")
 if [[ "$REPO_TYPE" == "backend-with-client" ]]; then
     info "Working with client repository: $REPO_PATH"
 fi
-
-# Color codes for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
-
-# Helper functions
-info() {
-    echo -e "${BLUE}ℹ${NC} $1"
-}
-
-success() {
-    echo -e "${GREEN}✅${NC} $1"
-}
-
-warning() {
-    echo -e "${YELLOW}⚠️${NC} $1"
-}
-
-error() {
-    echo -e "${RED}❌${NC} $1"
-}
-
-section() {
-    echo ""
-    echo "========================================="
-    echo "$1"
-    echo "========================================="
-    echo ""
-}
 
 # Detect issue type for template selection
 detect_issue_type() {


### PR DESCRIPTION
# Summary
Fix `scripts/prmerge` immediate failure when `REPO_TYPE == "backend-with-client"`. The script called `info()` on line 82 before the function was defined on line 93, causing bash to invoke the system `/usr/bin/info` command instead, which exited non-zero and aborted the script due to `set -e`.

## Goal / Acceptance Criteria (required)
- [x] Helper functions (`info()`, `success()`, `warning()`, `error()`, `section()`) are defined before first use
- [x] Color codes are defined before helper functions use them
- [x] Bash syntax validation passes

## Validation (required)
- [x] Syntax check: `bash -n scripts/prmerge` (passed)
- [x] Verified functions moved to lines 27-54 (before first usage on line 82)

## Changes
Moved helper function definitions and color codes from lines 88-112 to lines 27-54 (immediately after `set -e` on line 24), ensuring all functions are defined before they can be invoked.

Fixes #220