### PR TITLE
chore(ci): add evidence-first CI incident template and governance policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/ci_gate_incident.yml
+++ b/.github/ISSUE_TEMPLATE/ci_gate_incident.yml
@@ -1,0 +1,103 @@
+name: CI Gate Incident
+description: Report a failing CI gate with evidence-first triage details
+title: "ci: "
+labels: ["ci", "bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template when CI is failing or when an older CI issue needs re-scoping.
+
+        **Evidence-first rule:**
+        A CI incident issue must include a failing run URL, failing job/step, and a local reproduction attempt.
+
+  - type: input
+    id: failing-run-url
+    attributes:
+      label: Failing Workflow Run URL
+      description: Link to the exact failed GitHub Actions run
+      placeholder: https://github.com/blecx/AI-Agent-Framework/actions/runs/...
+    validations:
+      required: true
+
+  - type: input
+    id: failing-workflow
+    attributes:
+      label: Failing Workflow / Job / Step
+      description: Name the workflow and failing job/step precisely
+      placeholder: "Backend CI Quality Gates / Gate 6: Linting / Run flake8"
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproducible-command
+    attributes:
+      label: Local Reproduction Command(s)
+      description: Exact command(s) run locally to reproduce
+      placeholder: |
+        source .venv/bin/activate
+        python -m flake8 apps/api/
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction-output
+    attributes:
+      label: Reproduction Output
+      description: Paste relevant local output and/or CI logs
+      placeholder: Paste error output here
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-vs-actual
+    attributes:
+      label: Expected vs Actual
+      description: Describe what should happen and what happened instead
+      value: |
+        **Expected**
+        -
+
+        **Actual**
+        -
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope Proposal
+      description: Define precise in-scope and out-of-scope work
+      value: |
+        ## In Scope
+        -
+
+        ## Out of Scope
+        -
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: Use testable, checkable completion criteria
+      value: |
+        - [ ]
+        - [ ]
+        - [ ]
+    validations:
+      required: true
+
+  - type: textarea
+    id: hygiene
+    attributes:
+      label: Repo Hygiene / Safety
+      value: |
+        - [ ] No changes to `projectDocs/`.
+        - [ ] No changes to `configs/llm.json`.
+        - [ ] No secrets added.
+    validations:
+      required: true

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -426,21 +426,26 @@ Changed files (2):
 
 ## Best Practices
 
+### CI Incident Governance (Open/Re-scope Policy)
+
+When opening a new CI issue or re-scoping an older one, require concrete evidence first:
+
+1. **Failed run URL** (exact GitHub Actions run)
+2. **Failing workflow/job/step** (precise name)
+3. **Local reproduction command** and output
+4. **Expected vs actual behavior**
+5. **Narrow scope** (clear In Scope / Out of Scope)
+
+Use the dedicated issue form: `.github/ISSUE_TEMPLATE/ci_gate_incident.yml`.
+
+If the original acceptance criteria are already satisfied, close the old issue with validation evidence and open a new, narrowly scoped CI incident issue only when a new failure is reproducible.
+
 ### When Adding New Code
 
 1. **Write tests first** (TDD approach)
-2. **Run tests locally** before pushing:
-   ```bash
-   pytest tests/
-   ```
-3. **Check coverage** for your changes:
-   ```bash
-   pytest tests/ --cov=apps/api --cov-report=term-missing
-   ```
-4. **Run full CI simulation**:
-   ```bash
-   ./scripts/ci_backend.sh
-   ```
+2. **Run tests locally** before pushing: `pytest tests/`
+3. **Check coverage** for your changes: `pytest tests/ --cov=apps/api --cov-report=term-missing`
+4. **Run full CI simulation**: `./scripts/ci_backend.sh`
 5. **Push to PR** and wait for CI to pass
 
 ### When CI Fails
@@ -490,9 +495,11 @@ A: Yes, use `./scripts/ci_backend.sh` which runs all gates except Gate 9 (flaky 
 **CI Status**: Check the [Actions tab](https://github.com/blecx/AI-Agent-Framework/actions) for recent runs.
 
 **Badges**: README.md shows CI status badges:
+
 - [![Backend Quality Gates](https://github.com/blecx/AI-Agent-Framework/actions/workflows/ci-backend.yml/badge.svg)](https://github.com/blecx/AI-Agent-Framework/actions/workflows/ci-backend.yml)
 
 **Key Metrics**:
+
 - Test execution time (target: <10 min)
 - Test coverage (target: 80%+)
 - Security scan results (target: 0 high-severity issues)
@@ -500,6 +507,6 @@ A: Yes, use `./scripts/ci_backend.sh` which runs all gates except Gate 9 (flaky 
 
 ---
 
-**Last Updated**: February 1, 2026  
+**Last Updated**: February 15, 2026  
 **CI Workflow Version**: 1.0  
 **Maintained By**: Backend Team


### PR DESCRIPTION
## Goal / Context
Implements #264 by introducing an evidence-first CI incident issue template and documenting the CI open/re-scope policy.

Fixes #264.

## Acceptance Criteria
- [x] `.github/ISSUE_TEMPLATE/ci_gate_incident.yml` exists and is selectable.
- [x] Template requires failing run URL, failing workflow/job/step, reproduction command/output, expected vs actual.
- [x] `docs/ci-cd.md` includes concise CI incident governance policy.
- [x] Links and labels are consistent with existing issue templates.

## Validation Evidence
- [x] Verified new template file present under `.github/ISSUE_TEMPLATE/`.
- [x] Reviewed docs update in `docs/ci-cd.md` for policy clarity and consistency.
- [x] Verified `git status` includes only intended files before commit.
- [x] CI expected to run meta-gates for this docs/template-only PR.

## Repo Hygiene / Safety
- [x] No changes to `projectDocs/`.
- [x] No changes to `configs/llm.json`.
- [x] No secrets added.
