### PR TITLE
docs(planning): reconcile Step 2 completion checklist with issue state

### DIFF
--- a/planning/step-2-complete-status.md
+++ b/planning/step-2-complete-status.md
@@ -7,6 +7,8 @@
 **Issues Created:** 18 (9 backend + 7 UX + 2 E2E tests)  
 **Requirements Coverage:** 100% (9/9 requirements fully scoped)
 
+**Reconciliation Note (2026-02-15):** GitHub issue states were re-verified; #77 and #78 are closed and reflected below.
+
 ---
 
 ## Summary
@@ -33,8 +35,8 @@ Step 2 planning is **complete and ready for implementation**. All requirements h
 - [x] #74 - Step 2.06 — Artifact REST API endpoints (✅ MERGED PR #101)
 - [x] #75 - Step 2.07 — Proposal domain models (✅ MERGED PR #99)
 - [x] #76 - Step 2.08 — Proposal service (propose, apply, reject) (✅ MERGED PR #100)
-- [ ] #77 - Step 2.09 — Proposal REST API endpoints
-- [ ] #78 - Step 2.17 — End-to-end tests for complete Step 2 workflow (backend)
+- [x] #77 - Step 2.09 — Proposal REST API endpoints (✅ CLOSED)
+- [x] #78 - Step 2.17 — End-to-end tests for complete Step 2 workflow (backend) (✅ CLOSED)
 
 ### UX (blecx/AI-Agent-Framework-Client)
 
@@ -198,7 +200,7 @@ Step 2 is **COMPLETE** when:
 
 ### Functional
 
-- [ ] All 18 issues closed
+- [x] All 18 issues closed
 - [ ] All acceptance criteria met
 - [ ] All E2E tests pass (backend + client)
 - [ ] No critical bugs


### PR DESCRIPTION
## Goal / Context
Reconciles stale Step 2 planning status markers with current GitHub issue state for traceability accuracy.

Fixes #270.

## Acceptance Criteria
- [x] #77 and #78 are marked closed/checked in `planning/step-2-complete-status.md`.
- [x] "All 18 issues closed" checklist item reflects current reality.
- [x] Reconciliation note with date and evidence source added.

## Validation Evidence
- [x] Verified #77 and #78 are CLOSED via GitHub issue state.
- [x] Confirmed updates in `planning/step-2-complete-status.md`.
- [x] Confirmed docs-only change set.

## Repo Hygiene / Safety
- [x] No changes to `projectDocs/`.
- [x] No changes to `configs/llm.json`.
- [x] No secrets added.
