### PR TITLE
refactor(agent-tools): modularize tools and typed error handling

### DIFF
--- a/agents/tooling/__init__.py
+++ b/agents/tooling/__init__.py
@@ -1,0 +1,1 @@
+"""Typed modular tooling helpers for agent workflows."""

--- a/agents/tooling/contracts.py
+++ b/agents/tooling/contracts.py
@@ -1,0 +1,40 @@
+"""Typed contracts for agent tooling operations."""
+
+from dataclasses import dataclass
+from typing import Generic, Optional, TypeVar
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class ToolError:
+    """Structured error metadata for tool failures."""
+
+    code: str
+    message: str
+    details: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class ToolResult(Generic[T]):
+    """Typed success/failure result for tooling operations."""
+
+    ok: bool
+    value: Optional[T] = None
+    error: Optional[ToolError] = None
+
+    @classmethod
+    def success(cls, value: T) -> "ToolResult[T]":
+        return cls(ok=True, value=value)
+
+    @classmethod
+    def failure(
+        cls,
+        *,
+        code: str,
+        message: str,
+        details: Optional[str] = None,
+    ) -> "ToolResult[T]":
+        return cls(
+            ok=False, error=ToolError(code=code, message=message, details=details)
+        )

--- a/agents/tooling/filesystem_tools.py
+++ b/agents/tooling/filesystem_tools.py
@@ -1,0 +1,90 @@
+"""Filesystem-related tool implementations with typed contracts."""
+
+from pathlib import Path
+
+from agents.tooling.contracts import ToolResult
+
+
+def read_file_content_typed(
+    file_path: str,
+    base_directory: str = ".",
+) -> ToolResult[str]:
+    """Read contents of a file."""
+    try:
+        path = Path(base_directory) / file_path
+        if not path.exists():
+            return ToolResult.failure(
+                code="FILE_NOT_FOUND",
+                message=f"File {file_path} does not exist",
+            )
+
+        if path.stat().st_size > 1_000_000:
+            return ToolResult.failure(
+                code="FILE_TOO_LARGE",
+                message=f"File {file_path} is too large (>1MB)",
+            )
+
+        with open(path, "r", encoding="utf-8") as handle:
+            return ToolResult.success(handle.read())
+    except Exception as exc:
+        return ToolResult.failure(
+            code="IO_ERROR",
+            message="Error reading file",
+            details=str(exc),
+        )
+
+
+def write_file_content_typed(
+    file_path: str,
+    content: str,
+    base_directory: str = ".",
+) -> ToolResult[str]:
+    """Write content to a file, creating directories if needed."""
+    try:
+        path = Path(base_directory) / file_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(content)
+
+        return ToolResult.success(
+            f"Successfully wrote {len(content)} bytes to {file_path}"
+        )
+    except Exception as exc:
+        return ToolResult.failure(
+            code="IO_ERROR",
+            message="Error writing file",
+            details=str(exc),
+        )
+
+
+def list_directory_contents_typed(
+    directory_path: str,
+    base_directory: str = ".",
+) -> ToolResult[str]:
+    """List files and directories in a given path."""
+    try:
+        path = Path(base_directory) / directory_path
+        if not path.exists():
+            return ToolResult.failure(
+                code="DIRECTORY_NOT_FOUND",
+                message=f"Directory {directory_path} does not exist",
+            )
+
+        if not path.is_dir():
+            return ToolResult.failure(
+                code="NOT_A_DIRECTORY",
+                message=f"{directory_path} is not a directory",
+            )
+
+        entries = []
+        for item in sorted(path.iterdir()):
+            entries.append(f"{item.name}/" if item.is_dir() else item.name)
+
+        return ToolResult.success("\n".join(entries))
+    except Exception as exc:
+        return ToolResult.failure(
+            code="IO_ERROR",
+            message="Error listing directory",
+            details=str(exc),
+        )

--- a/agents/tooling/git_tools.py
+++ b/agents/tooling/git_tools.py
@@ -1,0 +1,124 @@
+"""Git-related tool implementations with typed contracts."""
+
+import subprocess
+
+from agents.tooling.contracts import ToolResult
+
+
+def git_commit_typed(
+    message: str,
+    working_directory: str = ".",
+) -> ToolResult[str]:
+    """Stage all changes and create a git commit."""
+    try:
+        subprocess.run(
+            ["git", "add", "-A"],
+            check=True,
+            capture_output=True,
+            cwd=working_directory,
+        )
+
+        result = subprocess.run(
+            ["git", "commit", "-m", message],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            cwd=working_directory,
+        )
+
+        if result.returncode != 0:
+            return ToolResult.failure(
+                code="COMMAND_FAILED",
+                message="Failed to create git commit",
+                details=result.stderr.strip() or "git commit failed",
+            )
+
+        hash_result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=working_directory,
+        )
+
+        return ToolResult.success(
+            f"Committed: {hash_result.stdout.strip()}\n{result.stdout}"
+        )
+    except Exception as exc:
+        return ToolResult.failure(
+            code="UNEXPECTED_EXCEPTION",
+            message="Unexpected error while creating git commit",
+            details=str(exc),
+        )
+
+
+def get_changed_files_typed(
+    working_directory: str = ".",
+) -> ToolResult[str]:
+    """Get list of files changed in working directory."""
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            cwd=working_directory,
+        )
+
+        if result.returncode != 0:
+            return ToolResult.failure(
+                code="COMMAND_FAILED",
+                message="Failed to get changed files",
+                details=result.stderr.strip() or "git status failed",
+            )
+
+        return ToolResult.success(result.stdout)
+    except Exception as exc:
+        return ToolResult.failure(
+            code="UNEXPECTED_EXCEPTION",
+            message="Unexpected error while fetching changed files",
+            details=str(exc),
+        )
+
+
+def create_feature_branch_typed(
+    branch_name: str,
+    working_directory: str = ".",
+) -> ToolResult[str]:
+    """Create and checkout a new feature branch from main."""
+    try:
+        subprocess.run(
+            ["git", "switch", "main"],
+            check=True,
+            capture_output=True,
+            cwd=working_directory,
+        )
+        subprocess.run(
+            ["git", "pull", "origin", "main"],
+            check=True,
+            capture_output=True,
+            cwd=working_directory,
+        )
+
+        result = subprocess.run(
+            ["git", "switch", "-c", branch_name],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            cwd=working_directory,
+        )
+
+        if result.returncode != 0:
+            return ToolResult.failure(
+                code="COMMAND_FAILED",
+                message="Failed to create feature branch",
+                details=result.stderr.strip() or "git switch -c failed",
+            )
+
+        return ToolResult.success(f"Created and checked out branch: {branch_name}")
+    except Exception as exc:
+        return ToolResult.failure(
+            code="UNEXPECTED_EXCEPTION",
+            message="Unexpected error while creating feature branch",
+            details=str(exc),
+        )

--- a/agents/tooling/github_tools.py
+++ b/agents/tooling/github_tools.py
@@ -1,0 +1,138 @@
+"""GitHub-related tool implementations with typed contracts."""
+
+import subprocess
+from typing import Optional
+
+from agents.tooling.contracts import ToolResult
+
+
+def fetch_github_issue_typed(
+    issue_number: int,
+    repo: Optional[str] = None,
+    working_directory: str = ".",
+) -> ToolResult[str]:
+    """Fetch GitHub issue details using gh CLI."""
+    try:
+        cmd = [
+            "gh",
+            "issue",
+            "view",
+            str(issue_number),
+            "--json",
+            "number,title,body,labels,state,assignees",
+        ]
+        if repo:
+            cmd.extend(["--repo", repo])
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            cwd=working_directory,
+        )
+
+        if result.returncode != 0:
+            return ToolResult.failure(
+                code="COMMAND_FAILED",
+                message="Failed to fetch GitHub issue",
+                details=result.stderr.strip() or "gh issue view failed",
+            )
+
+        return ToolResult.success(result.stdout)
+    except Exception as exc:
+        return ToolResult.failure(
+            code="UNEXPECTED_EXCEPTION",
+            message="Unexpected error while fetching GitHub issue",
+            details=str(exc),
+        )
+
+
+def create_github_pr_typed(
+    title: str,
+    body: str,
+    working_directory: str = ".",
+) -> ToolResult[str]:
+    """Create GitHub pull request with gh CLI."""
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "create", "--title", title, "--body", body],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            cwd=working_directory,
+        )
+
+        if result.returncode != 0:
+            return ToolResult.failure(
+                code="COMMAND_FAILED",
+                message="Failed to create pull request",
+                details=result.stderr.strip() or "gh pr create failed",
+            )
+
+        return ToolResult.success(result.stdout)
+    except Exception as exc:
+        return ToolResult.failure(
+            code="UNEXPECTED_EXCEPTION",
+            message="Unexpected error while creating pull request",
+            details=str(exc),
+        )
+
+
+def list_github_issues_typed(
+    repo: str,
+    state: str = "open",
+    limit: int = 50,
+    label: Optional[str] = None,
+    search: Optional[str] = None,
+    working_directory: str = ".",
+) -> ToolResult[str]:
+    """List GitHub issues via gh CLI."""
+    try:
+        state_norm = (state or "open").strip().lower()
+        if state_norm in {"opened"}:
+            state_norm = "open"
+        if state_norm not in {"open", "closed"}:
+            return ToolResult.failure(
+                code="INVALID_ARGUMENT",
+                message="state must be 'open' or 'closed'",
+            )
+
+        cmd = [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            state_norm,
+            "--limit",
+            str(limit),
+            "--json",
+            "number,title,labels,createdAt,updatedAt,author,assignees",
+        ]
+        if label:
+            cmd.extend(["--label", label])
+        if search:
+            cmd.extend(["--search", search])
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            cwd=working_directory,
+        )
+        if result.returncode != 0:
+            return ToolResult.failure(
+                code="COMMAND_FAILED",
+                message="Failed to list GitHub issues",
+                details=result.stderr.strip() or "gh issue list failed",
+            )
+        return ToolResult.success(result.stdout)
+    except Exception as exc:
+        return ToolResult.failure(
+            code="UNEXPECTED_EXCEPTION",
+            message="Unexpected error while listing GitHub issues",
+            details=str(exc),
+        )

--- a/agents/tools.py
+++ b/agents/tools.py
@@ -18,11 +18,43 @@ from typing import Annotated, Optional
 from agents.command_cache import get_cache
 from agents.coverage_analyzer import get_coverage_analyzer
 from agents.time_estimator import TimeEstimator
+from agents.tooling.filesystem_tools import (
+    list_directory_contents_typed,
+    read_file_content_typed,
+    write_file_content_typed,
+)
+from agents.tooling.git_tools import (
+    create_feature_branch_typed,
+    get_changed_files_typed,
+    git_commit_typed,
+)
+from agents.tooling.github_tools import (
+    create_github_pr_typed,
+    fetch_github_issue_typed,
+    list_github_issues_typed,
+)
 
 
 # ============================================================================
 # GitHub Tools
 # ============================================================================
+
+
+def _legacy_result_or_error(
+    result,
+    *,
+    error_prefix: str,
+    fallback_error_message: str,
+) -> str:
+    """Convert typed results to legacy string responses for compatibility."""
+    if result.ok:
+        return result.value or ""
+
+    details = None
+    if result.error:
+        details = result.error.details or result.error.message
+    details = details or fallback_error_message
+    return f"{error_prefix}{details}"
 
 
 def fetch_github_issue(
@@ -35,32 +67,16 @@ def fetch_github_issue(
 
     Returns JSON string with issue title, body, labels, etc.
     """
-    try:
-        cmd = [
-            "gh",
-            "issue",
-            "view",
-            str(issue_number),
-            "--json",
-            "number,title,body,labels,state,assignees",
-        ]
-        if repo:
-            cmd.extend(["--repo", repo])
-
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=30,
-            cwd=working_directory,
-        )
-
-        if result.returncode != 0:
-            return f"Error fetching issue: {result.stderr}"
-
-        return result.stdout
-    except Exception as e:
-        return f"Error: {str(e)}"
+    result = fetch_github_issue_typed(
+        issue_number=issue_number,
+        repo=repo,
+        working_directory=working_directory,
+    )
+    return _legacy_result_or_error(
+        result,
+        error_prefix="Error fetching issue: ",
+        fallback_error_message="failed to fetch issue",
+    )
 
 
 def create_github_pr(
@@ -73,21 +89,16 @@ def create_github_pr(
 
     Returns PR URL or error message.
     """
-    try:
-        result = subprocess.run(
-            ["gh", "pr", "create", "--title", title, "--body", body],
-            capture_output=True,
-            text=True,
-            timeout=30,
-            cwd=working_directory,
-        )
-
-        if result.returncode != 0:
-            return f"Error creating PR: {result.stderr}"
-
-        return result.stdout
-    except Exception as e:
-        return f"Error: {str(e)}"
+    result = create_github_pr_typed(
+        title=title,
+        body=body,
+        working_directory=working_directory,
+    )
+    return _legacy_result_or_error(
+        result,
+        error_prefix="Error creating PR: ",
+        fallback_error_message="failed to create pull request",
+    )
 
 
 def list_github_issues(
@@ -102,43 +113,22 @@ def list_github_issues(
 
     Returns JSON array string with fields needed for selection/triage.
     """
-    try:
-        state_norm = (state or "open").strip().lower()
-        if state_norm in {"opened"}:
-            state_norm = "open"
-        if state_norm not in {"open", "closed"}:
-            return "Error: state must be 'open' or 'closed'"
+    result = list_github_issues_typed(
+        repo=repo,
+        state=state,
+        limit=limit,
+        label=label,
+        search=search,
+        working_directory=working_directory,
+    )
+    if (not result.ok) and result.error and result.error.code == "INVALID_ARGUMENT":
+        return f"Error: {result.error.message}"
 
-        cmd = [
-            "gh",
-            "issue",
-            "list",
-            "--repo",
-            repo,
-            "--state",
-            state_norm,
-            "--limit",
-            str(limit),
-            "--json",
-            "number,title,labels,createdAt,updatedAt,author,assignees",
-        ]
-        if label:
-            cmd.extend(["--label", label])
-        if search:
-            cmd.extend(["--search", search])
-
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=30,
-            cwd=working_directory,
-        )
-        if result.returncode != 0:
-            return f"Error listing issues: {result.stderr}"
-        return result.stdout
-    except Exception as e:
-        return f"Error: {str(e)}"
+    return _legacy_result_or_error(
+        result,
+        error_prefix="Error listing issues: ",
+        fallback_error_message="failed to list issues",
+    )
 
 
 # ============================================================================
@@ -155,18 +145,26 @@ def read_file_content(
 
     Returns file content or error message.
     """
-    try:
-        path = Path(base_directory) / file_path
-        if not path.exists():
-            return f"Error: File {file_path} does not exist"
+    result = read_file_content_typed(
+        file_path=file_path,
+        base_directory=base_directory,
+    )
+    if (
+        (not result.ok)
+        and result.error
+        and result.error.code
+        in {
+            "FILE_NOT_FOUND",
+            "FILE_TOO_LARGE",
+        }
+    ):
+        return f"Error: {result.error.message}"
 
-        if path.stat().st_size > 1_000_000:  # 1MB limit
-            return f"Error: File {file_path} is too large (>1MB)"
-
-        with open(path, "r", encoding="utf-8") as f:
-            return f.read()
-    except Exception as e:
-        return f"Error reading file: {str(e)}"
+    return _legacy_result_or_error(
+        result,
+        error_prefix="Error reading file: ",
+        fallback_error_message="failed to read file",
+    )
 
 
 def write_file_content(
@@ -179,16 +177,16 @@ def write_file_content(
 
     Returns success message or error.
     """
-    try:
-        path = Path(base_directory) / file_path
-        path.parent.mkdir(parents=True, exist_ok=True)
-
-        with open(path, "w", encoding="utf-8") as f:
-            f.write(content)
-
-        return f"Successfully wrote {len(content)} bytes to {file_path}"
-    except Exception as e:
-        return f"Error writing file: {str(e)}"
+    result = write_file_content_typed(
+        file_path=file_path,
+        content=content,
+        base_directory=base_directory,
+    )
+    return _legacy_result_or_error(
+        result,
+        error_prefix="Error writing file: ",
+        fallback_error_message="failed to write file",
+    )
 
 
 def list_directory_contents(
@@ -200,24 +198,26 @@ def list_directory_contents(
 
     Returns newline-separated list of entries.
     """
-    try:
-        path = Path(base_directory) / directory_path
-        if not path.exists():
-            return f"Error: Directory {directory_path} does not exist"
+    result = list_directory_contents_typed(
+        directory_path=directory_path,
+        base_directory=base_directory,
+    )
+    if (
+        (not result.ok)
+        and result.error
+        and result.error.code
+        in {
+            "DIRECTORY_NOT_FOUND",
+            "NOT_A_DIRECTORY",
+        }
+    ):
+        return f"Error: {result.error.message}"
 
-        if not path.is_dir():
-            return f"Error: {directory_path} is not a directory"
-
-        entries = []
-        for item in sorted(path.iterdir()):
-            if item.is_dir():
-                entries.append(f"{item.name}/")
-            else:
-                entries.append(item.name)
-
-        return "\n".join(entries)
-    except Exception as e:
-        return f"Error listing directory: {str(e)}"
+    return _legacy_result_or_error(
+        result,
+        error_prefix="Error listing directory: ",
+        fallback_error_message="failed to list directory",
+    )
 
 
 # ============================================================================
@@ -234,39 +234,15 @@ def git_commit(
 
     Returns commit hash or error message.
     """
-    try:
-        # Stage all changes
-        subprocess.run(
-            ["git", "add", "-A"],
-            check=True,
-            capture_output=True,
-            cwd=working_directory,
-        )
-
-        # Commit
-        result = subprocess.run(
-            ["git", "commit", "-m", message],
-            capture_output=True,
-            text=True,
-            timeout=30,
-            cwd=working_directory,
-        )
-
-        if result.returncode != 0:
-            return f"Error committing: {result.stderr}"
-
-        # Get commit hash
-        hash_result = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
-            capture_output=True,
-            text=True,
-            check=True,
-            cwd=working_directory,
-        )
-
-        return f"Committed: {hash_result.stdout.strip()}\n{result.stdout}"
-    except Exception as e:
-        return f"Error: {str(e)}"
+    result = git_commit_typed(
+        message=message,
+        working_directory=working_directory,
+    )
+    return _legacy_result_or_error(
+        result,
+        error_prefix="Error committing: ",
+        fallback_error_message="failed to commit",
+    )
 
 
 def get_changed_files(
@@ -277,21 +253,11 @@ def get_changed_files(
 
     Returns list of changed files or empty string.
     """
-    try:
-        result = subprocess.run(
-            ["git", "status", "--porcelain"],
-            capture_output=True,
-            text=True,
-            timeout=30,
-            cwd=working_directory,
-        )
-
-        if result.returncode != 0:
-            return f"Error: {result.stderr}"
-
-        return result.stdout
-    except Exception as e:
-        return f"Error: {str(e)}"
+    result = get_changed_files_typed(working_directory=working_directory)
+    if not result.ok:
+        details = result.error.details if result.error else "failed to read git status"
+        return f"Error: {details}"
+    return result.value or ""
 
 
 def create_feature_branch(
@@ -303,36 +269,15 @@ def create_feature_branch(
 
     Returns success message or error.
     """
-    try:
-        # Checkout main and pull latest
-        subprocess.run(
-            ["git", "checkout", "main"],
-            check=True,
-            capture_output=True,
-            cwd=working_directory,
-        )
-        subprocess.run(
-            ["git", "pull", "origin", "main"],
-            check=True,
-            capture_output=True,
-            cwd=working_directory,
-        )
-
-        # Create and checkout new branch
-        result = subprocess.run(
-            ["git", "checkout", "-b", branch_name],
-            capture_output=True,
-            text=True,
-            timeout=30,
-            cwd=working_directory,
-        )
-
-        if result.returncode != 0:
-            return f"Error creating branch: {result.stderr}"
-
-        return f"Created and checked out branch: {branch_name}"
-    except Exception as e:
-        return f"Error: {str(e)}"
+    result = create_feature_branch_typed(
+        branch_name=branch_name,
+        working_directory=working_directory,
+    )
+    return _legacy_result_or_error(
+        result,
+        error_prefix="Error creating branch: ",
+        fallback_error_message="failed to create branch",
+    )
 
 
 # ============================================================================

--- a/tests/agents/test_tools_modular_typed.py
+++ b/tests/agents/test_tools_modular_typed.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Tests for modular agent tools and typed contracts."""
+
+import subprocess
+from pathlib import Path
+
+from agents.tools import (
+    fetch_github_issue,
+    list_github_issues,
+    read_file_content,
+)
+from agents.tooling.filesystem_tools import read_file_content_typed
+from agents.tooling.git_tools import create_feature_branch_typed
+from agents.tooling.github_tools import (
+    fetch_github_issue_typed,
+    list_github_issues_typed,
+)
+
+
+class _FakeCalledProcess:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, command, **kwargs):
+        self.calls.append({"command": command, "kwargs": kwargs})
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+
+def test_fetch_github_issue_typed_returns_structured_failure(monkeypatch):
+    def _fail(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 1, stdout="", stderr="no auth")
+
+    monkeypatch.setattr(subprocess, "run", _fail)
+
+    result = fetch_github_issue_typed(280, repo="blecx/AI-Agent-Framework")
+
+    assert result.ok is False
+    assert result.error is not None
+    assert result.error.code == "COMMAND_FAILED"
+    assert result.error.message == "Failed to fetch GitHub issue"
+
+
+def test_fetch_github_issue_legacy_wrapper_keeps_string_compatibility(monkeypatch):
+    def _fail(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 1, stdout="", stderr="denied")
+
+    monkeypatch.setattr(subprocess, "run", _fail)
+
+    result = fetch_github_issue(280, repo="blecx/AI-Agent-Framework")
+
+    assert isinstance(result, str)
+    assert result.startswith("Error fetching issue: ")
+
+
+def test_list_github_issues_typed_rejects_invalid_state():
+    result = list_github_issues_typed(
+        repo="blecx/AI-Agent-Framework",
+        state="invalid",
+    )
+
+    assert result.ok is False
+    assert result.error is not None
+    assert result.error.code == "INVALID_ARGUMENT"
+    assert result.error.message == "state must be 'open' or 'closed'"
+
+
+def test_list_github_issues_legacy_wrapper_keeps_invalid_state_contract():
+    result = list_github_issues(
+        repo="blecx/AI-Agent-Framework",
+        state="invalid",
+    )
+
+    assert result == "Error: state must be 'open' or 'closed'"
+
+
+def test_read_file_content_typed_returns_structured_not_found(tmp_path: Path):
+    result = read_file_content_typed(
+        "missing.txt",
+        base_directory=str(tmp_path),
+    )
+
+    assert result.ok is False
+    assert result.error is not None
+    assert result.error.code == "FILE_NOT_FOUND"
+
+
+def test_read_file_content_legacy_wrapper_keeps_not_found_string(tmp_path: Path):
+    result = read_file_content("missing.txt", base_directory=str(tmp_path))
+
+    assert result == "Error: File missing.txt does not exist"
+
+
+def test_create_feature_branch_typed_uses_modern_git_switch(monkeypatch):
+    fake_run = _FakeCalledProcess()
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = create_feature_branch_typed("feat/issue-280")
+
+    assert result.ok is True
+    assert result.value == "Created and checked out branch: feat/issue-280"
+    assert fake_run.calls[0]["command"] == ["git", "switch", "main"]
+    assert fake_run.calls[2]["command"] == ["git", "switch", "-c", "feat/issue-280"]


### PR DESCRIPTION
## Goal / Context

Modularize `agents/tools.py` by extracting core tool domains (GitHub, filesystem, git) into focused modules with typed success/failure contracts, while preserving legacy string-based behavior for existing call sites. Fixes #280.

## Acceptance Criteria

- [x] Core tool domains are separated into focused modules.
- [x] Migrated tool paths no longer rely on ambiguous `"Error: ..."` string protocol.
- [x] Existing workflows keep working (compatibility maintained).
- [x] Tests cover typed success/failure handling for migrated paths.

## Validation Evidence

- [x] `/home/sw/work/AI-Agent-Framework/.venv/bin/python -m black agents/tools.py agents/tooling/contracts.py agents/tooling/github_tools.py agents/tooling/filesystem_tools.py agents/tooling/git_tools.py tests/agents/test_tools_modular_typed.py` → `4 files reformatted, 2 files left unchanged`.
- [x] `/home/sw/work/AI-Agent-Framework/.venv/bin/python -m flake8 agents/tools.py agents/tooling/contracts.py agents/tooling/github_tools.py agents/tooling/filesystem_tools.py agents/tooling/git_tools.py tests/agents/test_tools_modular_typed.py` → passed (no output).
- [x] `/home/sw/work/AI-Agent-Framework/.venv/bin/python -m pytest tests/agents -q` → `34 passed, 12 warnings`.
- [x] `/home/sw/work/AI-Agent-Framework/.venv/bin/python -c "from agents.tools import get_all_tools; t=get_all_tools(); print(len(t)); print(any(x.__name__=='fetch_github_issue' for x in t)); print(any(x.__name__=='run_command' for x in t))"` → `15 / True / True`.

## Repo Hygiene / Safety

- [x] No changes to `projectDocs/`.
- [x] No changes to `configs/llm.json`.
- [x] No secrets added.
