### PR TITLE
fix(agent): correct repo detection for workflow validation scope (fixes #294)

### DIFF
--- a/agents/workflow_phase_services.py
+++ b/agents/workflow_phase_services.py
@@ -12,6 +12,18 @@ import time
 from typing import Any, Dict, Protocol
 
 
+def _detect_validation_repo_type(agent: Any) -> str:
+    """Resolve validation repo type using cross-repo context when available."""
+
+    context = getattr(agent, "cross_repo_context", None)
+    current_repo = getattr(context, "current_repo", None)
+
+    if current_repo in {"backend", "client"}:
+        return current_repo
+
+    return "backend"
+
+
 @dataclass
 class PhaseExecutionResult:
     """Normalized result for a workflow phase execution."""
@@ -27,6 +39,7 @@ class WorkflowPhaseService(Protocol):
 
     def execute(self, agent: Any, issue_num: int) -> PhaseExecutionResult:
         """Execute a phase using the provided agent and issue number."""
+        ...
 
 
 class MethodDelegatingPhaseService:
@@ -227,7 +240,7 @@ class TestingPhaseService:
         start_time = time.time()
 
         client_dir = Path("_external/AI-Agent-Framework-Client")
-        repo_type = "client" if client_dir.exists() else "backend"
+        repo_type = _detect_validation_repo_type(agent)
 
         agent.log("🔍 Analyzing changes for smart validation...", "progress")
         validation_commands = agent.smart_validation.get_validation_commands(repo_type)

--- a/tests/agents/test_workflow_phase_services.py
+++ b/tests/agents/test_workflow_phase_services.py
@@ -14,6 +14,7 @@ from agents.workflow_phase_services import (
     PhaseExecutionResult,
     ReviewPhaseService,
     TestingPhaseService,
+    _detect_validation_repo_type,
     build_default_phase_services,
 )
 
@@ -118,3 +119,86 @@ def test_workflow_agent_execute_regression_with_stubbed_phase_services(tmp_path)
 
     assert success is True
     assert all(phase.completed for phase in agent.phases)
+
+
+class _RepoContextStub:
+    def __init__(self, current_repo):
+        self.current_repo = current_repo
+
+
+class _SmartValidationStub:
+    def __init__(self):
+        self.repo_type = None
+
+    def get_validation_commands(self, repo_type: str):
+        self.repo_type = repo_type
+        return ["echo validate"]
+
+
+class _RecoveryStub:
+    def attempt_recovery(self, _error_output, _context):
+        return False, ""
+
+
+class _AgentStub:
+    def __init__(self, repo_type):
+        self.cross_repo_context = _RepoContextStub(repo_type)
+        self.smart_validation = _SmartValidationStub()
+        self.error_recovery = _RecoveryStub()
+        self.commands = []
+
+    def log(self, _message, _level):
+        return None
+
+    def run_command(self, command, _description, check=False):
+        self.commands.append(command)
+
+        class _Result:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return _Result()
+
+    def check_known_problem(self, _error_output):
+        return None
+
+
+def test_detect_validation_repo_type_uses_cross_repo_context_when_client():
+    agent = _AgentStub("client")
+
+    assert _detect_validation_repo_type(agent) == "client"
+
+
+def test_detect_validation_repo_type_defaults_to_backend_when_unknown():
+    agent = _AgentStub("unknown")
+
+    assert _detect_validation_repo_type(agent) == "backend"
+
+
+def test_testing_phase_service_uses_client_repo_context_for_validation_scope():
+    service = TestingPhaseService()
+    agent = _AgentStub("client")
+
+    result = service.execute(agent, 294)
+
+    assert result.success is True
+    assert agent.smart_validation.repo_type == "client"
+    assert any(
+        command.startswith("cd _external/AI-Agent-Framework-Client &&")
+        for command in agent.commands
+    )
+
+
+def test_testing_phase_service_uses_backend_repo_context_for_validation_scope():
+    service = TestingPhaseService()
+    agent = _AgentStub("backend")
+
+    result = service.execute(agent, 294)
+
+    assert result.success is True
+    assert agent.smart_validation.repo_type == "backend"
+    assert all(
+        not command.startswith("cd _external/AI-Agent-Framework-Client &&")
+        for command in agent.commands
+    )


### PR DESCRIPTION
## Goal / Context
- [x] Fix workflow validation scoping so Phase 4 runs commands in the correct repository context.
- [x] Address issue #294: "fix(agent): correct repo detection for workflow validation scope".

## Acceptance Criteria
- [x] Validation repo type detection uses cross-repo context when available.
- [x] Client context executes validation commands from `_external/AI-Agent-Framework-Client`.
- [x] Backend/unknown context defaults to backend validation scope.
- [x] Workflow phase service tests cover repo detection and command prefix behavior.

## Validation Evidence
- [x] Targeted tests passed locally:
  - `/home/sw/work/AI-Agent-Framework/.venv/bin/python -m pytest tests/agents/test_workflow_phase_services.py -q`
  - Result: `10 passed, 1 warning`.
- [x] Diagnostics check on changed files reports no errors.

## Repo Hygiene / Safety
- [x] Diff scoped to issue-relevant files only:
  - `agents/workflow_phase_services.py`
  - `tests/agents/test_workflow_phase_services.py`
- [x] No merge conflict markers remain in changed files.
- [x] Working tree clean after commit and branch pushed.

Fixes #294