### PR TITLE
refactor(agent): centralize validation command profiles (SSOT)

### DIFF
--- a/agents/validation_profiles.py
+++ b/agents/validation_profiles.py
@@ -1,0 +1,50 @@
+"""Canonical validation command profiles for workflow agents.
+
+This module provides a single source of truth for validation command sets used
+across workflow orchestration and phase services.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+
+_PROFILE_MAP = {
+    "backend": {
+        "full": [
+            "python -m black apps/api/",
+            "python -m flake8 apps/api/",
+            "pytest",
+        ],
+        "test_only": [
+            "python -m black apps/api/",
+            "python -m flake8 apps/api/",
+            "pytest",
+        ],
+        "type_only": ["python -m mypy apps/api/"],
+        "doc_only": [],
+    },
+    "client": {
+        "full": ["npm run lint", "npm test", "npm run build"],
+        "test_only": ["npm run lint", "npm test"],
+        "type_only": ["npx tsc --noEmit", "npm run lint"],
+        "doc_only": ["npx markdownlint '**/*.md' --ignore node_modules"],
+    },
+}
+
+
+def get_validation_commands(repo_type: str, profile: str = "full") -> List[str]:
+    """Return validation commands for a repo/profile combination.
+
+    Unknown repo/profile combinations return an empty list.
+    """
+
+    repo_profiles = _PROFILE_MAP.get(repo_type)
+    if not repo_profiles:
+        return []
+
+    commands = repo_profiles.get(profile)
+    if not commands:
+        return []
+
+    return list(commands)

--- a/agents/workflow_phase_services.py
+++ b/agents/workflow_phase_services.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import time
 from typing import Any, Dict, Protocol
 
+from agents.validation_profiles import get_validation_commands
+
 
 def _detect_validation_repo_type(agent: Any) -> str:
     """Resolve validation repo type using cross-repo context when available."""
@@ -277,14 +279,7 @@ class TestingPhaseService:
             agent.log(
                 "⚠️  No validation commands determined, using defaults", "warning"
             )
-            if repo_type == "client":
-                validation_commands = ["npm run lint", "npm test", "npm run build"]
-            else:
-                validation_commands = [
-                    "python -m black apps/api/",
-                    "python -m flake8 apps/api/",
-                    "pytest",
-                ]
+            validation_commands = get_validation_commands(repo_type, "full")
         else:
             agent.log(
                 f"📋 Smart validation determined {len(validation_commands)} commands:",

--- a/tests/agents/test_validation_profiles.py
+++ b/tests/agents/test_validation_profiles.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Tests for centralized validation command profiles."""
+
+from agents.validation_profiles import get_validation_commands
+
+
+def test_get_validation_commands_returns_backend_full_profile():
+    assert get_validation_commands("backend", "full") == [
+        "python -m black apps/api/",
+        "python -m flake8 apps/api/",
+        "pytest",
+    ]
+
+
+def test_get_validation_commands_returns_client_full_profile():
+    assert get_validation_commands("client", "full") == [
+        "npm run lint",
+        "npm test",
+        "npm run build",
+    ]
+
+
+def test_get_validation_commands_handles_unknown_repo_or_profile():
+    assert get_validation_commands("unknown", "full") == []
+    assert get_validation_commands("backend", "unknown") == []

--- a/tests/agents/test_workflow_phase_services.py
+++ b/tests/agents/test_workflow_phase_services.py
@@ -17,6 +17,7 @@ from agents.workflow_phase_services import (
     _detect_validation_repo_type,
     build_default_phase_services,
 )
+from agents.validation_profiles import get_validation_commands
 
 
 class _BoolAgent:
@@ -260,3 +261,19 @@ def test_context_phase_service_prompts_when_interactive_mode_enabled(monkeypatch
 
     assert result.success is True
     assert prompts == ["Press Enter when ready to continue to Planning phase..."]
+
+
+def test_testing_phase_service_fallback_uses_canonical_backend_defaults():
+    class _EmptySmartValidationStub(_SmartValidationStub):
+        def get_validation_commands(self, repo_type: str):
+            self.repo_type = repo_type
+            return []
+
+    service = TestingPhaseService()
+    agent = _AgentStub("backend")
+    agent.smart_validation = _EmptySmartValidationStub()
+
+    result = service.execute(agent, 297)
+
+    assert result.success is True
+    assert result.output["commands"] == get_validation_commands("backend", "full")


### PR DESCRIPTION
## Goal / Context
- [x] Centralize workflow validation command profiles into one canonical SSOT source to reduce drift risk.
- [x] Refactor workflow modules to consume canonical profiles without changing command semantics.

## Acceptance Criteria
- [x] Validation command sets are defined in one canonical location.
- [x] `workflow_agent.py` and phase services consume canonical source.
- [x] Tests verify expected commands per repo/type of change.

## Validation Evidence
- [x] Agent tests required by issue passed locally:
  - `/home/sw/work/AI-Agent-Framework/.venv/bin/python -m pytest tests/agents -q`
  - Result: `56 passed, 12 warnings in 1.85s`.

## Repo Hygiene / Safety
- [x] Diff scoped to issue-relevant files only:
  - `agents/validation_profiles.py`
  - `agents/workflow_agent.py`
  - `agents/workflow_phase_services.py`
  - `tests/agents/test_validation_profiles.py`
  - `tests/agents/test_workflow_phase_services.py`
  - `tests/agents/test_workflow_side_effect_adapters.py`
- [x] No tutorial files changed.
- [x] No secrets added.

Fixes #297
