### PR TITLE
docs(setup): deduplicate install sections and centralize LLM setup guide

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,684 +1,184 @@
-# Quick Start Guide
+# Quick Start (Backend + Client)
 
-This guide shows you how to get the ISO 21500 Project Management AI Agent system up and running.
+This guide gives you the fastest path to run the AI-Agent-Framework with:
 
-> **💡 Multi-Repository Project:** This project includes a separate client repository at [AI-Agent-Framework-Client](https://github.com/blecx/AI-Agent-Framework-Client). For full-stack development, see the [Development Guide](docs/development.md#cross-repository-coordination) for cross-repo workflow.
+- **Backend API** (`apps/api`)
+- **Web client** (`apps/web`)
+- Optional terminal clients (`client/`, `apps/tui`)
 
-## Prerequisites
+For the full installation + LLM guide (Docker images, local setup, troubleshooting), see:
 
-- Docker and Docker Compose installed
-- (Optional) LM Studio or another OpenAI-compatible LLM running locally
+- [Install & LLM Setup Guide](docs/howto/install-and-llm-setup.md)
 
-### System Requirements
+---
 
-**For Web UI (Browser-based):**
-- Desktop browser: Chrome, Firefox, Edge, or Safari (latest versions)
-- Minimum screen resolution: 1280x720
-- Mouse and keyboard recommended
+## 1) Prerequisites
 
-**Mobile/Tablet Support:**
-- ⚠️ Tablets (iPad, Android 10"+): Limited support, landscape mode only, read-only recommended
-- ❌ Smartphones: Not supported (screen too small for UI)
-- See [Mobile Compatibility Guide](docs/clients/README.md#mobile-browser-compatibility) for details
+- Python **3.10+** (3.12 recommended)
+- Node.js **20+** (for local web development)
+- Git
+- Docker + Docker Compose (for containerized setup)
 
-**For TUI/CLI:**
-- Terminal with color support
-- SSH access (for remote use)
-- Works on any device with terminal access (including mobile via SSH)
+---
 
-## Setup Steps
+## 2) Fastest path: Docker (recommended)
 
-### 1. Clone the Repository
+1. Clone and enter the repo:
 
 ```bash
 git clone https://github.com/blecx/AI-Agent-Framework.git
 cd AI-Agent-Framework
 ```
 
-### 2. Project Documents Directory
-
-By default the compose configuration uses a Docker named volume for project documents so no manual step is required.
-
-If you prefer to keep project documents on your host filesystem, create the directory before starting services:
-
-```bash
-# Optional: create host directory for persistent docs (only needed if you want host-managed files)
-mkdir -p projectDocs
-```
-
-The API will initialize the repository inside the docs directory on first run.
-
-### 3. (Optional) Configure LLM
-
-The system works with or without an LLM. Without an LLM, it will use fallback template-based generation.
-
-To use an LLM, create or edit `configs/llm.json`:
-
-```json
-{
-  "provider": "lmstudio",
-  "base_url": "http://host.docker.internal:1234/v1",
-  "api_key": "lm-studio",
-  "model": "local-model",
-  "temperature": 0.7,
-  "max_tokens": 4096,
-  "timeout": 120
-}
-```
-
-For LM Studio:
-
-1. Download and install LM Studio
-2. Load a model (e.g., CodeLlama, Mistral, or any chat model)
-3. Start the local server (Server tab → Start Server)
-4. Use the config above (default)
-
-For OpenAI:
-
-```json
-{
-  "provider": "openai",
-  "base_url": "https://api.openai.com/v1",
-  "api_key": "your-openai-api-key",
-  "model": "gpt-4",
-  "temperature": 0.7,
-  "max_tokens": 4096
-}
-```
-
-### 4. Start the Services
-
-```bash
-docker compose up --build
-```
-
-This will:
-
-- Build the FastAPI backend
-- Build the React frontend
-- Start both services
-- Initialize the `/projectDocs` git repository if needed
-
-### 5. Access the Application
-
-- **Web UI**: <http://localhost:8080>
-- **API**: <http://localhost:8000>
-- **API Docs**: <http://localhost:8000/docs>
-- **Client CLI**: Use `docker compose run client <command>`
-
-### 6. (Optional) Try the Client
-
-The client provides both interactive (TUI) and command-line (CLI) access:
-
-#### 🖥️ Terminal User Interface (NEW!)
-
-Launch an interactive visual interface:
-
-```bash
-# Launch TUI (default)
-docker compose run client
-
-# Or explicitly
-docker compose run client tui
-```
-
-Navigate with keyboard/mouse, manage projects, run commands, and view artifacts in real-time!
-
-#### 📟 Command Line Interface
-
-Traditional CLI for automation:
-
-```bash
-# Show help and available commands
-docker compose run client --help
-
-# Create a project via CLI
-docker compose run client create-project --key CLI001 --name "CLI Test Project"
-
-# List all projects
-docker compose run client list-projects
-
-# Run a complete demo workflow
-docker compose run client demo --key DEMO001 --name "Demo via CLI"
-```
-
-For detailed client usage, see [client/README.md](client/README.md).
-
-## Choosing the Right Client
-
-The AI-Agent Framework offers multiple interfaces to match your workflow:
-
-### Available Clients
-
-1. **TUI (Text User Interface)** - `apps/tui/` - Command-line client for automation
-2. **Advanced Client** - `client/` - CLI + interactive terminal UI (with Textual)
-3. **WebUI** - Separate repository - Modern web-based graphical interface
-
-### Decision Guide
-
-**Use TUI (`apps/tui/`) when:**
-
-- ✅ Running in CI/CD pipelines
-- ✅ Writing automation scripts
-- ✅ Need simple, fast command-line operations
-- ✅ Working in minimal environments
-
-**Use Advanced Client (`client/`) when:**
-
-- ✅ Working in terminal/SSH sessions but want visual navigation
-- ✅ Need interactive feedback in terminal
-- ✅ Debugging or testing the API
-- ✅ Want both CLI scripting and interactive TUI modes
-
-**Use WebUI (separate repo) when:**
-
-- ✅ Need rich visual interface
-- ✅ Managing projects interactively
-- ✅ Working with non-technical team members
-- ✅ Want visual diff review and artifact preview
-
-## Getting Started with TUI
-
-The TUI client is a simple command-line tool included in this repository.
-
-**Docker:**
-
-```bash
-# Show help
-docker compose run tui --help
-
-# Create project
-docker compose run tui projects create --key PROJ001 --name "My Project"
-
-# List projects
-docker compose run tui projects list
-
-# Propose command
-docker compose run tui commands propose --project PROJ001 --command assess_gaps
-```
-
-**Local:**
-
-```bash
-cd apps/tui
-python -m venv .venv
-source .venv/bin/activate  # Windows: .venv\Scripts\activate
-pip install -r requirements.txt
-python main.py health
-```
-
-**Full documentation:** [apps/tui/README.md](apps/tui/README.md)
-
-## Getting Started with Advanced Client
-
-The advanced client provides both CLI and interactive TUI modes.
-
-**Docker (Interactive TUI):**
-
-```bash
-# Launch interactive TUI (default)
-docker compose run client
-
-# Or explicitly
-docker compose run client tui
-```
-
-**Docker (CLI mode):**
-
-```bash
-# Run CLI commands
-docker compose run client --help
-docker compose run client create-project --key TEST001 --name "Test"
-docker compose run client demo --key DEMO001 --name "Demo Project"
-```
-
-**Local:**
-
-```bash
-cd client
-python -m venv .venv
-source .venv/bin/activate  # Windows: .venv\Scripts\activate
-pip install -r requirements.txt
-python -m src.client tui  # Interactive mode
-python -m src.client health  # CLI mode
-```
-
-**Full documentation:** [client/README.md](client/README.md)
-
-## Next Steps
-
-Now that you have the system running, here's where to go next:
-
-### Learn Through Tutorials
-
-Our comprehensive tutorial suite will teach you everything from basics to advanced workflows:
-
-**🌱 Beginner Path (60 minutes):**
-
-- [TUI Quick Start](docs/tutorials/tui-basics/01-quick-start.md) - Docker setup and basic commands (5 min)
-- [First Project](docs/tutorials/tui-basics/02-first-project.md) - Create your first project (10 min)
-- [Web Interface Basics](docs/tutorials/gui-basics/01-web-interface.md) - Navigate the web UI (5 min)
-- [Complete Beginner Path](docs/tutorials/README.md#-beginner-path-60-minutes) - Full guided tour
-
-**🚀 Intermediate Path (110 minutes):**
-
-- Learn workflow management and ISO 21500 lifecycle
-- [View Intermediate Path](docs/tutorials/README.md#-intermediate-path-110-minutes)
-
-**🎯 Advanced Path (220 minutes):**
-
-- Master hybrid workflows and automation
-- [View Advanced Path](docs/tutorials/README.md#-advanced-path-220-minutes)
-
-**📚 All Tutorials:** [docs/tutorials/README.md](docs/tutorials/README.md)
-
-### Explore the System
-
-After tutorials, dive deeper into capabilities:
-
-## Getting Started with WebUI
-
-The WebUI is a **separate repository** with a modern React-based interface.
-
-**Repository:** [blecx/AI-Agent-Framework-Client](https://github.com/blecx/AI-Agent-Framework-Client)
-
-**Quick Start:**
-
-1. Clone the WebUI repository:
-
-   ```bash
-   git clone https://github.com/blecx/AI-Agent-Framework-Client.git
-   ```
-
-2. Follow the setup instructions in the WebUI repository's README
-
-3. Ensure the AI-Agent-Framework API is running (this repository)
-
-4. Configure the WebUI to connect to your API endpoint
-
-**Note:** The Docker setup in this repository already includes a web frontend at `apps/web/`. The separate WebUI repository provides an alternative, enhanced interface with additional features.
-
-**When to use each web interface:**
-
-- **`apps/web/`** (included): Quick setup, basic features, integrated deployment
-- **Separate WebUI repo**: Enhanced features, independent updates, customizable
-
-For detailed WebUI setup and features, visit: [https://github.com/blecx/AI-Agent-Framework-Client](https://github.com/blecx/AI-Agent-Framework-Client)
-
-## Using the System
-
-You can interact with the system through multiple interfaces. Below are examples using the included web UI and clients.
-
-### Using the Web UI (Included)
-
-#### Create a Project
-
-1. Open <http://localhost:8080>
-2. Click "Create New Project"
-3. Enter a project key (e.g., `PROJ001`) - alphanumeric, dashes, underscores only
-4. Enter a project name (e.g., `Website Redesign`)
-5. Click "Create Project"
-
-#### Run Commands
-
-The system supports three main commands:
-
-##### 1. Assess Gaps
-
-Analyzes your project against ISO 21500 standards and identifies missing artifacts.
-
-1. Click the "Assess Gaps" card
-2. Click "Propose Changes"
-3. Review the gap assessment report in the modal
-4. Click "Apply & Commit" to save the report
-
-##### 2. Generate Artifact
-
-Creates specific project management documents.
-
-1. Click the "Generate Artifact" card
-2. Enter the artifact name (e.g., `project_charter.md`)
-3. Enter the artifact type (e.g., `project_charter`)
-4. Click "Propose Changes"
-5. Review the generated document
-6. Click "Apply & Commit" to save
-
-##### 3. Generate Plan
-
-Creates a project schedule with timeline and Mermaid gantt chart.
-
-1. Click the "Generate Plan" card
-2. Click "Propose Changes"
-3. Review the generated schedule
-4. Click "Apply & Commit" to save
-
-#### View Artifacts
-
-1. Click the "Artifacts" tab
-2. See all generated documents
-3. Click any artifact to view its content
-
-#### View Project Documents
-
-All project documents are stored in `./projectDocs/` as a separate git repository:
-
-```bash
-cd projectDocs
-git log                    # View commit history
-ls -la PROJ001/           # View project files
-cat PROJ001/project.json  # View project metadata
-```
-
-### Using the CLI Clients
-
-Both the TUI and Advanced Client provide command-line access for automation:
-
-#### Using the CLI Clients
-
-Both the TUI and Advanced Client provide command-line access for automation.
-
-**TUI Client (`apps/tui/`)** - Simple CLI:
-
-```bash
-# Create a project
-docker compose run tui projects create --key PROJ001 --name "My Project"
-
-# List projects
-docker compose run tui projects list
-
-# Propose command
-docker compose run tui commands propose --project PROJ001 --command assess_gaps
-
-# Apply proposal
-docker compose run tui commands apply --project PROJ001 --proposal <proposal-id>
-```
-
-**Advanced Client (`client/`)** - CLI + Interactive TUI:
-
-```bash
-# Create a project
-docker compose run client create-project --key CLI001 --name "CLI Project"
-
-# Check project state
-docker compose run client get-state --key CLI001
-
-# Propose assess_gaps command
-docker compose run client propose --key CLI001 --command assess_gaps
-
-# Note the proposal_id from output, then apply it
-docker compose run client apply --key CLI001 --proposal-id <proposal-id>
-
-# List artifacts
-docker compose run client list-artifacts --key CLI001
-
-# View artifact content
-docker compose run client get-artifact --key CLI001 --path artifacts/gap_assessment.md
-
-# Or run a complete demo workflow
-docker compose run client demo --key DEMO001 --name "Automated Demo"
-```
-
-**Client Usage Summary:**
-
-| Client                          | Best For                                  | Documentation                                                          |
-| ------------------------------- | ----------------------------------------- | ---------------------------------------------------------------------- |
-| **TUI** (`apps/tui/`)           | Simple CLI automation, quick commands     | [apps/tui/README.md](apps/tui/README.md)                               |
-| **Advanced Client** (`client/`) | Interactive terminal + CLI, rich feedback | [client/README.md](client/README.md)                                   |
-| **WebUI** (separate repo)       | Visual interface, team collaboration      | [WebUI Repository](https://github.com/blecx/AI-Agent-Framework-Client) |
-
-For more examples and detailed documentation, see the respective client README files.
-
-## Troubleshooting
-
-### API Cannot Connect to LLM
-
-If you see `[LLM unavailable: ...]` messages:
-
-1. Ensure your LLM server is running
-2. Check the `base_url` in `configs/llm.json`
-3. For LM Studio, verify it's on port 1234
-4. The system will still work with template-based fallbacks
-
-### Docker Build Fails
-
-If you encounter SSL certificate errors during build:
-
-```bash
-# Rebuild with no cache
-docker compose build --no-cache
-
-# Or use the API Dockerfile's trusted host flags (already included)
-```
-
-### Ports Already in Use
-
-If ports 8000 or 8080 are already in use:
-
-```bash
-# Stop the services
-docker compose down
-
-# Edit docker-compose.yml to use different ports
-# Then restart
-docker compose up --build
-```
-
-### Cannot Access from Host
-
-If using LM Studio and the API can't reach it:
-
-- Ensure LM Studio is running on the host machine
-- The URL `http://host.docker.internal:1234` should work on Docker Desktop
-- On Linux, you may need to use `http://172.17.0.1:1234` or your host IP
-
-## Advanced Usage
-
-## Local Development (without Docker)
-
-If you prefer to develop without Docker, you can run the application directly on your local machine using a Python virtual environment.
-
-### Prerequisites
-
-- **Python 3.12** (matches GitHub Actions CI)
-- **Git**
-- **Node.js 18+** (for web UI)
-- (Optional) LM Studio or OpenAI-compatible LLM endpoint
-
-### Setup Steps
-
-1. **Clone the repository:**
-
-```bash
-git clone https://github.com/blecx/AI-Agent-Framework.git
-cd AI-Agent-Framework
-```
-
-1. **Run the intelligent setup script:**
-
-The setup script uses Python 3.12 to create the virtual environment and sets up your environment.
-
-**Linux/macOS:**
-
-```bash
-./setup.sh
-```
-
-**Windows (PowerShell - Recommended):**
-
-```powershell
-.\setup.ps1
-```
-
-**Windows (Command Prompt):**
-
-```cmd
-setup.bat
-```
-
-**Script features:**
-
-- 🔍 Detects Python 3.12 on your system
-- 🔒 Fails fast with install instructions if Python 3.12 is missing
-- 📦 Creates `.venv/` with Python 3.12
-- ⬆️ Upgrades pip and installs all dependencies
-- 💡 Provides helpful install instructions if Python 3.12 is missing
-
-This will:
-
-- Create a virtual environment in `.venv/`
-- Install all Python dependencies
-- Display next steps
-
-1. **Activate the virtual environment:**
-
-**Linux/macOS:**
-
-```bash
-source .venv/bin/activate
-```
-
-**Windows (PowerShell):**
-
-```powershell
-.\.venv\Scripts\Activate.ps1
-```
-
-**Windows (Command Prompt):**
-
-```cmd
-.venv\Scripts\activate.bat
-```
-
-1. **Create project documents directory:**
-
-```bash
-mkdir projectDocs
-```
-
-1. **Configure LLM (optional):**
+1. (Optional) Create a custom LLM config:
 
 ```bash
 cp configs/llm.default.json configs/llm.json
-# Edit configs/llm.json with your LLM settings
 ```
 
-For local LLM (LM Studio):
+1. Start services:
 
-- Ensure LM Studio is running on `http://localhost:1234`
-- Update `configs/llm.json`:
+```bash
+docker compose up --build
+```
 
-  ```json
-  {
-    "provider": "lmstudio",
-    "base_url": "http://localhost:1234/v1",
-    "api_key": "lm-studio",
-    "model": "local-model"
-  }
-  ```
+1. Open:
 
-1. **Run the API server:**
+- Web UI: <http://localhost:8080>
+- API: <http://localhost:8000>
+- API docs: <http://localhost:8000/docs>
+
+---
+
+## 3) Local path: Codebase development setup
+
+1. Clone and enter the repo:
+
+```bash
+git clone https://github.com/blecx/AI-Agent-Framework.git
+cd AI-Agent-Framework
+```
+
+1. Setup Python environment:
+
+```bash
+./setup.sh
+source .venv/bin/activate
+mkdir -p projectDocs
+```
+
+1. (Optional) Configure LLM:
+
+```bash
+cp configs/llm.default.json configs/llm.json
+```
+
+1. Start API:
 
 ```bash
 cd apps/api
 PROJECT_DOCS_PATH=../../projectDocs uvicorn main:app --reload
 ```
 
-The API will be available at:
-
-- <http://localhost:8000>
-- API Docs: <http://localhost:8000/docs>
-
-1. **(Optional) Run the Web UI:**
+1. Start web client in another terminal:
 
 ```bash
-# In a new terminal
 cd apps/web
 npm install
 npm run dev
 ```
 
-The web UI will be available at <http://localhost:5173>
+1. Open:
 
-### When to Use Local Development vs Docker
-
-**Use Local Development (.venv) when:**
-
-- You're actively developing and debugging code
-- You need faster iteration cycles
-- You want to use your IDE's debugger
-- You need to inspect or modify dependencies
-- You're running on a development machine
-
-**Use Docker when:**
-
-- You want a consistent environment across team members
-- You're deploying to production
-- You need to test the full system integration
-- You want isolated environments
-- You're distributing the application to others
-
-### Switching Between Local and Docker
-
-You can easily switch between local and Docker development:
-
-**To Docker:**
-
-```bash
-deactivate  # Exit virtual environment if active
-docker compose up --build
-```
-
-**To Local:**
-
-```bash
-docker compose down
-source .venv/bin/activate  # or .venv\Scripts\activate.bat on Windows
-cd apps/api
-PROJECT_DOCS_PATH=../../projectDocs uvicorn main:app --reload
-```
+- Web dev UI: <http://localhost:5173>
+- API: <http://localhost:8000>
+- API docs: <http://localhost:8000/docs>
 
 ---
 
-## Docker Deployment (Production)
+## 4) LLM setup examples
 
-For production deployment or if you prefer Docker, continue using the Docker setup described in the earlier sections of this guide.
+Create `configs/llm.json` and choose one profile.
 
-### Customizing Templates
+### Example A: GitHub (Copilot/GitHub Models)
 
-Edit templates in:
-
-- `templates/prompts/iso21500/` - Jinja2 prompts for LLM
-- `templates/output/iso21500/` - Markdown output templates
-
-### Audit Logging
-
-Audit events are stored in:
-
+```json
+{
+  "provider": "github",
+  "base_url": "https://models.github.ai/inference",
+  "api_key": "github_pat_your_token_here",
+  "model": "openai/gpt-5.1-codex",
+  "temperature": 0.2,
+  "max_tokens": 16384,
+  "timeout": 300
+}
 ```
-projectDocs/[PROJECT_KEY]/events/events.ndjson
+
+### Example B: OpenAI
+
+```json
+{
+  "provider": "openai",
+  "base_url": "https://api.openai.com/v1",
+  "api_key": "sk-your-openai-key",
+  "model": "gpt-4.1",
+  "temperature": 0.2,
+  "max_tokens": 8192,
+  "timeout": 120
+}
 ```
 
-By default, only hashes are logged (no sensitive content). To enable full logging, modify the `log_content` parameter in `apps/api/routers/commands.py`.
+### Example C: Local LLM (LM Studio or Ollama)
 
-## Security Notes
+LM Studio:
 
-- Never commit the `projectDocs/` directory to your code repository
-- Store API keys securely (use environment variables or mounted config files)
-- The default configuration logs only hashes, not actual prompts or content
-- Review the `.gitignore` file to ensure sensitive files are excluded
+```json
+{
+  "provider": "lmstudio",
+  "base_url": "http://localhost:1234/v1",
+  "api_key": "lm-studio",
+  "model": "local-model",
+  "temperature": 0.2,
+  "max_tokens": 8192,
+  "timeout": 120
+}
+```
 
-## Next Steps
+Ollama (OpenAI-compatible endpoint):
 
-- Review the full [README.md](README.md) for detailed architecture information
-- Explore the API documentation at <http://localhost:8000/docs>
-- Customize templates for your specific needs
-- Integrate with CI/CD pipelines for automated project management
+```json
+{
+  "provider": "ollama",
+  "base_url": "http://localhost:11434/v1",
+  "api_key": "ollama",
+  "model": "llama3.1:8b",
+  "temperature": 0.2,
+  "max_tokens": 8192,
+  "timeout": 120
+}
+```
 
-## Support
+> Docker note: when API runs in a container and your LLM runs on host, use `http://host.docker.internal:<port>/v1` (Linux fallback: host bridge IP).
 
-For issues or questions:
+---
 
-- Check the [README.md](README.md) for detailed documentation
-- Review API logs: `docker compose logs api`
-- Review web logs: `docker compose logs web`
-- Check the GitHub repository for updates
+## 5) Quick verification
+
+- Health check:
+
+```bash
+curl http://localhost:8000/health
+```
+
+- Expected: JSON with `"status":"healthy"`
+
+---
+
+## 6) What to read next
+
+- Full install + Docker image workflow + local setup + LLM deep dive:
+  - [docs/howto/install-and-llm-setup.md](docs/howto/install-and-llm-setup.md)
+- Development workflow:
+  - [docs/development.md](docs/development.md)
+- Main project docs:
+  - [README.md](README.md)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This system provides intelligent project management following ISO 21500 standard
 **New to the project?** Start here:
 
 - 🚀 **[Quick Start Guide](QUICKSTART.md)** - Get up and running in 10 minutes
+- 🧰 **[Install & LLM Setup Guide](docs/howto/install-and-llm-setup.md)** - Docker images, local setup, and provider configuration examples
 - 📚 **[Tutorials](docs/tutorials/README.md)** - NEW! Step-by-step learning paths for all skill levels
 - � **[Issue Agent Chat](ISSUEAGENT-CHAT-SETUP.md)** - Run autonomous agent from VS Code chat
 - 🤝 **[Contributing Guide](docs/CONTRIBUTING.md)** - How to contribute to the project
@@ -231,137 +232,24 @@ After running, reload VS Code (`Ctrl+Shift+P` → `Developer: Reload Window`) to
 
 **Benefits**: No manual approval prompts when using Copilot agents, significantly faster workflow.
 
-## Local Development Setup
+## Installation & Setup
 
-For local development without Docker, follow these steps:
+To avoid duplicated setup instructions across docs, this repository uses:
 
-### Prerequisites
+- **Quick path:** [QUICKSTART.md](QUICKSTART.md)
+- **Canonical install + LLM guide:** [docs/howto/install-and-llm-setup.md](docs/howto/install-and-llm-setup.md)
 
-- **Python 3.12** (matches GitHub Actions CI)
-- **Git**
-- (Optional) LM Studio or OpenAI-compatible LLM endpoint
-- **Desktop browser** for Web UI: Chrome, Firefox, Edge, or Safari (latest versions)
-  - Minimum screen resolution: 1280x720
-  - ⚠️ Mobile/tablet support limited - see [Mobile Compatibility](docs/clients/README.md#mobile-browser-compatibility)
-
-### Step-by-Step Setup
-
-1. **Clone the repository:**
-
-```bash
-git clone https://github.com/blecx/AI-Agent-Framework.git
-cd AI-Agent-Framework
-```
-
-2. **Run the setup script:**
-
-The setup script requires Python 3.12 and will create a virtual environment using it.
-
-**Linux/macOS:**
+### Local quick reference
 
 ```bash
 ./setup.sh
-```
-
-**Windows (PowerShell):**
-
-```powershell
-.\setup.ps1
-```
-
-**Windows (Command Prompt):**
-
-```cmd
-setup.bat
-```
-
-**What the script does:**
-
-- 🔍 Detects Python 3.12 on your system
-- 🔒 Fails fast with install instructions if Python 3.12 is missing
-- 📦 Creates a Python virtual environment in `.venv/` using Python 3.12
-- ⬆️ Upgrades pip to the latest version
-- 📥 Installs all required dependencies from `requirements.txt`
-- ✨ Displays next steps for running the application
-
-If Python 3.12 is not found, the script will display install instructions.
-
-3. **Activate the virtual environment:**
-
-**Linux/macOS:**
-
-```bash
 source .venv/bin/activate
+mkdir -p projectDocs
+cp configs/llm.default.json configs/llm.json  # optional
+cd apps/api && PROJECT_DOCS_PATH=../../projectDocs uvicorn main:app --reload
 ```
 
-**Windows (PowerShell):**
-
-```powershell
-.\.venv\Scripts\Activate.ps1
-```
-
-**Windows (Command Prompt):**
-
-```cmd
-.venv\Scripts\activate.bat
-```
-
-4. **Create project documents directory:**
-
-```bash
-mkdir projectDocs
-```
-
-5. **Configure LLM settings (optional):**
-
-```bash
-cp configs/llm.default.json configs/llm.json
-# Edit configs/llm.json with your LLM endpoint details
-```
-
-6. **Run the API server:**
-
-```bash
-cd apps/api
-PROJECT_DOCS_PATH=../../projectDocs uvicorn main:app --reload
-```
-
-7. **Access the application:**
-
-- API: http://localhost:8000
-- API Docs: http://localhost:8000/docs
-
-**Note:** For the web UI, you'll need to run it separately (see Web UI section below) or use Docker.
-
-### Manual Setup (Alternative)
-
-If you prefer not to use the setup script, you can set up manually:
-
-1. **Check Python version:**
-
-   ```bash
-   python3 --version  # Should be 3.10 or higher
-   ```
-
-2. **Create virtual environment:**
-
-   ```bash
-   python3 -m venv .venv
-   ```
-
-3. **Activate and install dependencies:**
-
-   ```bash
-   source .venv/bin/activate  # Linux/macOS
-   # or .venv\Scripts\activate.bat on Windows
-
-   pip install --upgrade pip
-   pip install -r requirements.txt
-   ```
-
-### Running the Web UI (Optional)
-
-If you want to run the React frontend locally:
+In another terminal (optional web dev UI):
 
 ```bash
 cd apps/web
@@ -369,60 +257,18 @@ npm install
 npm run dev
 ```
 
-The web UI will be available at http://localhost:5173 (or the port shown in the terminal).
-
-### Docker Deployment Setup
-
-For production or simplified deployment using Docker:
-
-### Prerequisites
-
-- Docker and Docker Compose
-- (Optional) LM Studio or OpenAI-compatible LLM endpoint
-
-### Setup
-
-1. Clone this repository:
-
-```bash
-git clone https://github.com/blecx/AI-Agent-Framework.git
-cd AI-Agent-Framework
-```
-
-2. Create project documents directory:
-
-```bash
-mkdir projectDocs
-```
-
-3. (Optional) Configure LLM settings:
-
-```bash
-# Copy and edit the LLM config
-cp configs/llm.default.json configs/llm.json
-# Edit configs/llm.json with your LLM endpoint details
-```
-
-The default configuration uses LM Studio on `http://host.docker.internal:1234/v1`.
-
-4. Start the services:
+### Docker quick reference
 
 ```bash
 docker compose up --build
 ```
 
-This will start all three services:
+Endpoints:
 
-- API server (backend)
-- Web UI (frontend)
-- Client (CLI tool - optional)
-
-5. Access the application:
-
-- Web UI: http://localhost:8080
-- API: http://localhost:8000
-- API Docs: http://localhost:8000/docs
-- Client: `docker compose run client <command>` (see Client Usage below)
+- Web UI: <http://localhost:8080>
+- API: <http://localhost:8000>
+- API Docs: <http://localhost:8000/docs>
+- Client CLI/TUI: `docker compose run client <command>`
 
 ## Client Usage
 
@@ -549,30 +395,15 @@ AI-Agent-Framework/
 
 ## LLM Configuration
 
-The system uses a JSON configuration file for LLM settings. Create `configs/llm.json` to override defaults:
+LLM configuration examples are maintained in one place:
 
-```json
-{
-  "provider": "lmstudio",
-  "base_url": "http://host.docker.internal:1234/v1",
-  "api_key": "lm-studio",
-  "model": "local-model",
-  "temperature": 0.7,
-  "max_tokens": 4096,
-  "timeout": 120
-}
-```
+- [docs/howto/install-and-llm-setup.md#llm-connection-configuration](docs/howto/install-and-llm-setup.md#llm-connection-configuration)
 
-### Supported LLM Providers
+Supported examples include:
 
-Any OpenAI-compatible endpoint works:
-
-- LM Studio (default)
-- OpenAI API
-- Azure OpenAI
-- Ollama with OpenAI compatibility
-- LocalAI
-- Text Generation WebUI (with OpenAI extension)
+- GitHub Models (Copilot/GitHub)
+- OpenAI
+- Local LLMs (LM Studio, Ollama via OpenAI-compatible endpoint)
 
 ## Project Documents Storage
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Welcome to the comprehensive documentation for the ISO 21500 Project Management 
 
 **Quick Links:**
 - 🚀 [Setup Guide](../QUICKSTART.md)
+- 🧰 [Install & LLM Setup](howto/install-and-llm-setup.md)
 - 📚 [Tutorials](tutorials/README.md) - **NEW! Step-by-step learning paths**
 - 🤝 [Contributing Guide](CONTRIBUTING.md) - **Start here if you want to contribute!**
 - 💻 [Development Guide](development.md)
@@ -479,6 +480,7 @@ Step-by-step procedural guides for common tasks.
 | Guide | Description | Last Updated |
 |-------|-------------|--------------|
 | [Chat Context Storage](howto/chat-context-in-repo.md) | Best practices for storing and restoring conversational context in repositories | 2026-01-09 |
+| [Install & LLM Setup](howto/install-and-llm-setup.md) | End-to-end install guide for Docker images and local setup, plus GitHub/OpenAI/local LLM config examples | 2026-02-15 |
 
 **Topics Covered:**
 - Why store chat context?
@@ -570,7 +572,7 @@ Find all documentation related to a specific feature or decision.
 
 **Documentation:**
 - **Specification:** [MVP Spec - Docker Configuration](spec/mvp-iso21500-agent.md#docker-configuration)
-- **Setup Guide:** [Quick Start - Docker](../QUICKSTART.md#4-start-the-services)
+- **Setup Guide:** [Install & LLM Setup (Docker)](howto/install-and-llm-setup.md#option-a-docker-images-and-containers)
 - **Discussion:** [Chat Transcript - Part 4](chat/2026-01-09-blecx-copilot-transcript.md#part-4-docker-and-deployment)
 - **Configuration:**
   - `docker-compose.yml` - Orchestration

--- a/docs/development.md
+++ b/docs/development.md
@@ -100,6 +100,9 @@ Complete guide for local development of the ISO 21500 AI-Agent Framework.
    # Edit configs/llm.json with your settings
    ```
 
+   For provider-specific examples (GitHub Models, OpenAI, LM Studio, Ollama), use:
+   [docs/howto/install-and-llm-setup.md](howto/install-and-llm-setup.md)
+
 ---
 
 ## Project Structure
@@ -553,37 +556,26 @@ See `tests/README.md` for detailed testing documentation.
 
 ### Testing LLM Integration
 
-1. **Without LLM** (template fallback):
+Use the canonical provider setup examples and then validate behavior here:
+
+- [docs/howto/install-and-llm-setup.md#llm-connection-configuration](howto/install-and-llm-setup.md#llm-connection-configuration)
+
+Quick validation:
+
+1. **Without LLM** (template fallback)
    - Remove or don't configure `configs/llm.json`
-   - System will use template-based generation
-
-2. **With LM Studio:**
-   - Start LM Studio and load a model
-   - Start the local server (port 1234)
-   - Configure `configs/llm.json`:
-     ```json
-     {
-       "provider": "lmstudio",
-       "base_url": "http://localhost:1234/v1",
-       "api_key": "lm-studio",
-       "model": "local-model"
-     }
-     ```
-
-3. **With OpenAI:**
-   - Configure `configs/llm.json`:
-     ```json
-     {
-       "provider": "openai",
-       "base_url": "https://api.openai.com/v1",
-       "api_key": "your-api-key",
-       "model": "gpt-4"
-     }
-     ```
+   - System uses template-based generation
+2. **With configured LLM**
+   - Start API and run a command workflow
+   - Confirm responses are generated and no connection errors appear in logs
 
 ---
 
 ## Docker Integration
+
+For complete Docker install and image workflows, see:
+
+- [docs/howto/install-and-llm-setup.md#option-a-docker-images-and-containers](howto/install-and-llm-setup.md#option-a-docker-images-and-containers)
 
 ### How `.venv` and Docker Work Together
 

--- a/docs/howto/README.md
+++ b/docs/howto/README.md
@@ -1,0 +1,7 @@
+# How-To Guides
+
+- [Install & LLM Setup Guide](install-and-llm-setup.md)
+- [Develop with Chat Agents](develop-with-chat-agents.md)
+- [Restore Chat and Create Custom Agent](restore-chat-and-create-custom-agent.md)
+- [Chat Context in Repo](chat-context-in-repo.md)
+

--- a/docs/howto/install-and-llm-setup.md
+++ b/docs/howto/install-and-llm-setup.md
@@ -1,0 +1,268 @@
+# Install & LLM Setup Guide
+
+This guide is the complete reference for installing and running the project in two modes:
+
+- **Docker images / containers** (recommended for consistency)
+- **Local codebase setup** (recommended for development)
+
+It also includes LLM connection examples for:
+
+1. GitHub (Copilot/GitHub Models)
+2. OpenAI
+3. Local LLMs (LM Studio and Ollama)
+
+For a shorter version, see [QUICKSTART.md](../../QUICKSTART.md).
+
+---
+
+## Prerequisites
+
+- Python 3.10+ (3.12 recommended)
+- Node.js 20+ (for local web client development)
+- Git
+- Docker Engine + Docker Compose plugin
+
+---
+
+## Option A: Docker images and containers
+
+### A1. Clone repository
+
+```bash
+git clone https://github.com/blecx/AI-Agent-Framework.git
+cd AI-Agent-Framework
+```
+
+### A2. Configure LLM (optional)
+
+The compose file mounts `configs/llm.default.json` into the API container by default.
+
+To customize provider/model settings, create your own config and update the mount in `docker-compose.yml` if needed:
+
+```bash
+cp configs/llm.default.json configs/llm.json
+```
+
+Then change the API volume mount from:
+
+- `./configs/llm.default.json:/config/llm.json:ro`
+
+to:
+
+- `./configs/llm.json:/config/llm.json:ro`
+
+### A3. Build and start all services
+
+```bash
+docker compose up --build
+```
+
+Services started:
+
+- `api` (FastAPI backend) on `:8000`
+- `web` (Nginx + web app) on `:8080`
+- `client` (optional terminal client)
+- `tui` (optional CLI/TUI container)
+
+### A4. Access endpoints
+
+- Web UI: <http://localhost:8080>
+- API: <http://localhost:8000>
+- Swagger docs: <http://localhost:8000/docs>
+
+### A5. Optional image-only workflow
+
+If you want to explicitly build images first:
+
+```bash
+docker compose build
+docker compose up
+```
+
+Or build individual images:
+
+```bash
+docker build -f docker/api/Dockerfile -t iso21500-api:local .
+docker build -f docker/web/Dockerfile -t iso21500-web:local .
+docker build -f client/Dockerfile -t ai-agent-client:local ./client
+docker build -f docker/Dockerfile.tui -t iso21500-tui:local .
+```
+
+---
+
+## Option B: Local install from the codebase
+
+### B1. Clone repository
+
+```bash
+git clone https://github.com/blecx/AI-Agent-Framework.git
+cd AI-Agent-Framework
+```
+
+### B2. Setup Python backend environment
+
+Linux/macOS:
+
+```bash
+./setup.sh
+source .venv/bin/activate
+```
+
+Windows PowerShell:
+
+```powershell
+.\setup.ps1
+.\.venv\Scripts\Activate.ps1
+```
+
+### B3. Create docs storage directory
+
+```bash
+mkdir -p projectDocs
+```
+
+### B4. Configure LLM (optional)
+
+```bash
+cp configs/llm.default.json configs/llm.json
+```
+
+### B5. Start backend API
+
+```bash
+cd apps/api
+PROJECT_DOCS_PATH=../../projectDocs uvicorn main:app --reload
+```
+
+### B6. Start local web client (optional)
+
+In another terminal:
+
+```bash
+cd apps/web
+npm install
+npm run dev
+```
+
+Local endpoints:
+
+- API: <http://localhost:8000>
+- API docs: <http://localhost:8000/docs>
+- Web dev server: <http://localhost:5173>
+
+---
+
+## LLM connection configuration
+
+The backend reads LLM settings from JSON config (`LLM_CONFIG_PATH`, defaults to `/config/llm.json` in Docker).
+
+For local runs, create `configs/llm.json`.
+
+### 1) GitHub (Copilot/GitHub Models)
+
+Use GitHub Models endpoint with a GitHub token:
+
+```json
+{
+  "provider": "github",
+  "base_url": "https://models.github.ai/inference",
+  "api_key": "github_pat_your_token_here",
+  "model": "openai/gpt-5.1-codex",
+  "temperature": 0.2,
+  "max_tokens": 16384,
+  "timeout": 300
+}
+```
+
+### 2) OpenAI
+
+```json
+{
+  "provider": "openai",
+  "base_url": "https://api.openai.com/v1",
+  "api_key": "sk-your-openai-key",
+  "model": "gpt-4.1",
+  "temperature": 0.2,
+  "max_tokens": 8192,
+  "timeout": 120
+}
+```
+
+### 3) Local models
+
+#### LM Studio
+
+Start LM Studio server (default `:1234`) and use:
+
+```json
+{
+  "provider": "lmstudio",
+  "base_url": "http://localhost:1234/v1",
+  "api_key": "lm-studio",
+  "model": "local-model",
+  "temperature": 0.2,
+  "max_tokens": 8192,
+  "timeout": 120
+}
+```
+
+#### Ollama (OpenAI-compatible endpoint)
+
+Ensure Ollama is running and use:
+
+```json
+{
+  "provider": "ollama",
+  "base_url": "http://localhost:11434/v1",
+  "api_key": "ollama",
+  "model": "llama3.1:8b",
+  "temperature": 0.2,
+  "max_tokens": 8192,
+  "timeout": 120
+}
+```
+
+### Docker networking note for local LLMs
+
+If API runs in Docker but your LLM runs on the host machine:
+
+- Prefer `http://host.docker.internal:<port>/v1`
+- On Linux, if `host.docker.internal` is unavailable, use your host bridge IP
+
+Examples:
+
+- LM Studio in Docker mode: `http://host.docker.internal:1234/v1`
+- Ollama in Docker mode: `http://host.docker.internal:11434/v1`
+
+---
+
+## Verify installation
+
+```bash
+curl http://localhost:8000/health
+```
+
+Expected: JSON with `"status": "healthy"`.
+
+If LLM is not reachable, the system still runs and falls back to template-based generation.
+
+---
+
+## Troubleshooting quick hits
+
+- **API cannot reach local LLM while using Docker**:
+  - switch `localhost` to `host.docker.internal`
+- **Port conflict (8000/8080/5173)**:
+  - stop existing process or remap ports in compose/dev config
+- **Missing Python venv support on Linux**:
+  - install distro package for venv (example: `python3.12-venv`)
+- **No `configs/llm.json`**:
+  - copy from `configs/llm.default.json`
+
+---
+
+## Related docs
+
+- [Quick Start](../../QUICKSTART.md)
+- [Development Guide](../development.md)
+- [Main README](../../README.md)


### PR DESCRIPTION
## Goal / Context
- [x] Deduplicate older installation/setup sections in core docs.
- [x] Establish one canonical source for install + LLM provider setup details.
- [x] Keep quick-start experience intact while reducing maintenance drift.

## Acceptance Criteria
- [x] `README.md` now points to canonical install/LLM guide and removes repeated long setup blocks.
- [x] `docs/development.md` references canonical install/LLM guide for provider examples and Docker install flow.
- [x] `QUICKSTART.md` remains concise and links to deeper setup content.
- [x] New canonical guide exists with examples for GitHub Models, OpenAI, LM Studio, and Ollama.
- [x] No tutorial files changed.

## Validation Evidence
- [x] Scope and linkage validation run locally:
  - `git diff --name-only origin/main...HEAD`
  - `rg -n "install-and-llm-setup\.md" QUICKSTART.md README.md docs/README.md docs/development.md docs/howto/README.md`
  - Result:
    - Changed files are docs-only (`QUICKSTART.md`, `README.md`, `docs/README.md`, `docs/development.md`, `docs/howto/README.md`, `docs/howto/install-and-llm-setup.md`).
    - Canonical guide links are present across quickstart/readme/development/docs index.

## Repo Hygiene / Safety
- [x] Diff scoped to issue-relevant docs files only.
- [x] No tutorial files changed.
- [x] No secrets added.
- [x] `projectDocs/` and `configs/llm.json` not modified.

Fixes #304
