### PR TITLE
feat(agents): add tutorial custom agent mode with strict audit prompt wiring

### DIFF
--- a/.github/agents/README.md
+++ b/.github/agents/README.md
@@ -1,0 +1,25 @@
+# Custom Agent Registry
+
+This directory contains repository custom agents (`*.agent.md`) discoverable by Copilot Chat.
+
+## Available Agents
+
+- **[resolve-issue-dev.agent.md](./resolve-issue-dev.agent.md)** - Implement backend/client issues with plan-first execution and validation gates.
+- **[pr-merge.agent.md](./pr-merge.agent.md)** - Merge PRs safely with CI checks and issue closure workflow.
+- **[close-issue.agent.md](./close-issue.agent.md)** - Close issues with template-backed, traceable resolution comments.
+- **[tutorial.agent.md](./tutorial.agent.md)** - Create Markdown-only tutorials with strict visual evidence, feature-gap reporting, and duplicate-content audits.
+
+## Tutorial Agent Support Prompts
+
+When using `tutorial`, reference these prompt templates:
+
+- **Rails/guardrails:** [`../prompts/agents/tutorial.md`](../prompts/agents/tutorial.md)
+- **Default invocation:** [`../prompts/tutorial-default-prompt.md`](../prompts/tutorial-default-prompt.md)
+- **Full invocation:** [`../prompts/tutorial-invocation.md`](../prompts/tutorial-invocation.md)
+- **Strict audit mode:** [`../prompts/tutorial-audit-strict.md`](../prompts/tutorial-audit-strict.md)
+
+## Auto-Approve Wiring
+
+`tutorial` is enabled for subagent auto-approval in `.vscode/settings.json` under `chat.tools.subagent.autoApprove`.
+
+````

--- a/.github/agents/tutorial.agent.md
+++ b/.github/agents/tutorial.agent.md
@@ -20,6 +20,7 @@ Your mission is to produce **best-in-class tutorials** that are:
 ## Required Behaviors
 
 - Follow the rails in: `.github/prompts/agents/tutorial.md`.
+- For strict audit-only runs, use: `.github/prompts/tutorial-audit-strict.md` and keep its required Markdown result format.
 - Use scripted screenshot generation where possible (Playwright preferred).
 - Use draw.io source-controlled diagrams (`.drawio`) with generated SVG assets.
 - Validate documented steps against real behavior before finalizing.

--- a/.github/prompts/agents/README.md
+++ b/.github/prompts/agents/README.md
@@ -9,7 +9,7 @@ These prompts are automatically referenced by agents when running in their respe
 1. **VS Code Copilot Integration**: Agents are invoked via `chat.tools.subagent.autoApprove` settings
    - Configuration: See `docs/VSCODE-GLOBAL-SETTINGS.md`
    - Settings file: `.vscode/settings.json`
-   - Auto-approved agents: `resolve-issue-dev`, `close-issue`, `pr-merge`, `Plan`
+   - Auto-approved agents: `resolve-issue-dev`, `close-issue`, `pr-merge`, `Plan`, `tutorial`
 
 2. **Copilot Instructions**: These workflows are referenced in `.github/copilot-instructions.md`
    - Agents automatically follow these patterns when in their respective modes

--- a/.github/prompts/tutorial-invocation.md
+++ b/.github/prompts/tutorial-invocation.md
@@ -19,9 +19,9 @@ Mandatory requirements:
 2) Include screenshots for major user transitions (required).
 3) Include schema picture(s) with draw.io source + exported SVG references (required).
 4) Include workflow picture(s) visualizing end-to-end step flow (required).
-4) Detect logical breaks/functional gaps and add a "Feature Gap List" section for developers.
-5) Prevent duplicate content with existing tutorials.
-6) Keep UX and TUI content fully separated (self-contained learning path per track).
+5) Detect logical breaks/functional gaps and add a "Feature Gap List" section for developers.
+6) Prevent duplicate content with existing tutorials.
+7) Keep UX and TUI content fully separated (self-contained learning path per track).
 
 Deliverables (all Markdown):
 - Main tutorial document
@@ -127,4 +127,6 @@ Result format (Markdown only):
 4) Duplicate Content Audit (canonicalization plan)
 5) Visual Coverage Report (missing/available screenshots/schema/workflow pictures)
 6) Recommended Fix Plan (prioritized)
+
+Do not return alternate output structures in strict mode.
 ```

--- a/docs/VSCODE-GLOBAL-SETTINGS.md
+++ b/docs/VSCODE-GLOBAL-SETTINGS.md
@@ -23,7 +23,8 @@ To enable auto-approve globally across all VS Code instances (not just this work
     "resolve-issue-dev": true,
     "close-issue": true,
     "pr-merge": true,
-    "Plan": true
+    "Plan": true,
+    "tutorial": true
   },
   "chat.tools.terminal.autoApprove": {
     "npm install": true,
@@ -111,6 +112,7 @@ To enable auto-approve globally across all VS Code instances (not just this work
   - `close-issue`: Auto-approves issue closing operations (see `.github/prompts/agents/close-issue.md`)
   - `pr-merge`: Auto-approves PR merge operations (see `.github/prompts/agents/pr-merge.md`)
   - `Plan`: Auto-approves planning agent operations (see `.github/prompts/agents/Plan.md`)
+  - `tutorial`: Auto-approves tutorial generation/audit agent runs (see `.github/prompts/agents/tutorial.md`)
 
 **Note:** These agent names correspond to optimized workflow prompts in `.github/prompts/agents/` that implement early-exit conditions, batch operations, and eliminate polling loops to reduce resolution time from 30-45 minutes to 5-10 minutes.
 
@@ -176,6 +178,7 @@ If auto-approve doesn't work in a fresh chat:
 ## Agent Workflow References
 
 The auto-approved agents listed above use optimized workflows that implement:
+
 - **Early-exit conditions** (skip completed work)
 - **Single-pass operations** (no polling loops)
 - **Limited search scope** (max 5 results)
@@ -183,8 +186,10 @@ The auto-approved agents listed above use optimized workflows that implement:
 - **Clear success criteria** (testable conditions)
 
 For detailed workflow documentation:
+
 - `.github/prompts/agents/resolve-issue-dev.md` - Issue resolution workflow (9 steps)
 - `.github/prompts/agents/pr-merge.md` - PR merge with admin bypass (6 steps)
 - `.github/prompts/agents/close-issue.md` - Issue closure workflow (4 steps)
 - `.github/prompts/agents/Plan.md` - Research agent with limited scope (5 steps)
+- `.github/prompts/agents/tutorial.md` - Tutorial authoring and strict audit workflow rails
 - `.github/prompts/agents/README.md` - Optimization principles and performance metrics


### PR DESCRIPTION
## Goal / Context
Add and wire a dedicated `tutorial` custom agent mode with strict tutorial/audit prompt behavior so tutorial generation is Markdown-only, visual-first, and audit-ready.

Fixes: #287

## Acceptance Criteria
- [x] Custom `tutorial` agent exists and is discoverable.
- [x] Prompt rails enforce Markdown-only output.
- [x] Prompts require screenshots, schema pictures, and workflow pictures.
- [x] Strict audit mode prompt exists with explicit output/result format.
- [x] Prompts require Feature Gap List and Duplicate Content Audit.
- [x] UX and TUI are explicitly treated as separate self-contained paths.

## Validation Evidence
- [x] Markdown diagnostics/lint passed for changed prompt/agent docs
  - Command(s): `npx --yes markdownlint-cli2 --config .tmp/markdownlint-287.jsonc .github/agents/README.md .github/agents/tutorial.agent.md .github/prompts/agents/README.md .github/prompts/tutorial-invocation.md docs/VSCODE-GLOBAL-SETTINGS.md`
  - Evidence: Command completed with no lint violations emitted.
- [x] Backend validation gate passed
  - Command(s): `source .venv/bin/activate && python -m black --check apps/api/ && python -m flake8 apps/api/ && python -m pytest tests/ -q --tb=short`
  - Evidence: `All done! 74 files would be left unchanged.` and `767 passed, 29 skipped, 21 warnings in 178.21s (0:02:58)`.
- [x] Repository status contains only intended agent/prompt/docs files
  - Command(s): `git status --short`
  - Evidence:
    - `M .github/agents/tutorial.agent.md`
    - `M .github/prompts/agents/README.md`
    - `M .github/prompts/tutorial-invocation.md`
    - `M docs/VSCODE-GLOBAL-SETTINGS.md`
    - `?? .github/agents/README.md`

## Repo Hygiene / Safety
- [x] Backend repo only; no `_external/AI-Agent-Framework-Client` changes.
- [x] No changes under `projectDocs/`.
- [x] No changes to `configs/llm.json`.
- [x] No secrets added.
- [x] Strict tutorial/audit behavior documented and wired:
  - Agent registry added: `.github/agents/README.md`
  - Strict audit linkage in `.github/agents/tutorial.agent.md`
  - Prompt index wiring updated in `.github/prompts/agents/README.md`
  - Auto-approve docs aligned with actual settings in `docs/VSCODE-GLOBAL-SETTINGS.md`
