### PR TITLE
docs: fix tutorial RAID verb/path examples

### DIFF
--- a/docs/tutorials/shared/troubleshooting.md
+++ b/docs/tutorials/shared/troubleshooting.md
@@ -14,8 +14,9 @@ python apps/tui/main.py health
 Expected: current TUI has no `raid` command group.
 
 Use REST instead:
-- `GET/POST/PUT/DELETE /projects/{project_key}/raid`
-- or `/api/v1/projects/{project_key}/raid`
+- `GET/POST /projects/{project_key}/raid`
+- `PUT/DELETE /projects/{project_key}/raid/{raid_id}`
+- or `/api/v1/projects/{project_key}/raid` and `/api/v1/projects/{project_key}/raid/{raid_id}`
 
 ### “`main.py workflow` not found”
 Expected: current TUI has no workflow command group.


### PR DESCRIPTION
## Goal / Context

Docs-only follow-up to fix one remaining HTTP method/path mismatch in tutorial troubleshooting guidance.

## Acceptance Criteria

- [x] RAID troubleshooting examples correctly distinguish collection vs item endpoints
- [x] `PUT/DELETE` examples include required `{raid_id}` path segment
- [x] Changes are documentation-only

## Validation Evidence

- [x] Re-ran strict tutorial method+path audit against current FastAPI routers
- [x] Result: `mismatches 0`
- [x] Re-ran tutorial relative-link scan
- [x] Result: `missing links: 0`

## Repo Hygiene / Safety

- [x] No changes to `projectDocs/`
- [x] No secrets/config credentials added
- [x] Only tutorial markdown updated
