### PR TITLE
docs: normalize tutorial endpoint placeholder naming

### DIFF
--- a/docs/tutorials/ERROR-CATALOG.md
+++ b/docs/tutorials/ERROR-CATALOG.md
@@ -175,7 +175,7 @@ python apps/tui/main.py projects create --key TEST-123 --name "My Project"
 When diagnosing RAID or workflow-related 404 errors, use the current REST endpoints:
 
 - `GET /projects/{project_key}/raid`
-- `GET /projects/{project_key}/raid/{id}`
+- `GET /projects/{project_key}/raid/{raid_id}`
 - `GET /projects/{project_key}/workflow/state`
 - `GET /projects/{project_key}/workflow/allowed-transitions`
 

--- a/docs/tutorials/shared/performance-benchmarks.md
+++ b/docs/tutorials/shared/performance-benchmarks.md
@@ -40,13 +40,13 @@ All benchmarks were collected in a controlled environment:
 
 ### Project Management Commands
 
-| Command                             | Median Time | Min-Max  | Notes                                               |
-| ----------------------------------- | ----------- | -------- | --------------------------------------------------- |
-| `projects create`                   | 2.3s        | 2.1-2.8s | Includes git init + metadata write                  |
-| `projects list`                     | 0.4s        | 0.3-0.6s | Queries projectDocs directory                       |
-| `projects get <key>`                | 0.5s        | 0.4-0.7s | Reads metadata + git log                            |
-| Project deletion (legacy benchmark) | 1.8s        | 1.5-2.2s | Git cleanup + directory removal                     |
-| Workflow state transition (API)     | 1.2s        | 1.0-1.5s | `PATCH /projects/{key}/workflow/state` + git commit |
+| Command | Median Time | Min-Max | Notes |
+| --- | --- | --- | --- |
+| `projects create` | 2.3s | 2.1-2.8s | Includes git init + metadata write |
+| `projects list` | 0.4s | 0.3-0.6s | Queries projectDocs directory |
+| `projects get <key>` | 0.5s | 0.4-0.7s | Reads metadata + git log |
+| Project deletion (legacy benchmark) | 1.8s | 1.5-2.2s | Git cleanup + directory removal |
+| Workflow state transition (API) | 1.2s | 1.0-1.5s | `PATCH /projects/{project_key}/workflow/state` + git commit |
 
 **Performance Factors:**
 
@@ -181,14 +181,14 @@ All benchmarks were collected in a controlled environment:
 | --- | --- | --- | --- | --- |
 | `GET /health` | 8ms | 15ms | 25ms | No DB queries |
 | `GET /projects` | 45ms | 85ms | 120ms | 10 projects |
-| `GET /projects/{key}` | 55ms | 95ms | 140ms | Git log parsing |
+| `GET /projects/{project_key}` | 55ms | 95ms | 140ms | Git log parsing |
 | `POST /projects` | 2.3s | 2.8s | 3.5s | Git init + metadata |
-| `POST /projects/{key}/commands/propose` | 6.5s | 8.2s | 10.5s | LLM inference |
-| `POST /projects/{key}/commands/apply` | 1.5s | 1.9s | 2.4s | Git commit |
-| `GET /projects/{key}/artifacts` | 65ms | 110ms | 160ms | File listing |
-| `GET /projects/{key}/artifacts/{name}` | 90ms | 150ms | 220ms | File read + markdown |
-| `POST /projects/{key}/raid` | 1.8s | 2.3s | 2.9s | JSON write + git commit |
-| `GET /projects/{key}/raid` | 55ms | 95ms | 140ms | JSON read |
+| `POST /projects/{project_key}/commands/propose` | 6.5s | 8.2s | 10.5s | LLM inference |
+| `POST /projects/{project_key}/commands/apply` | 1.5s | 1.9s | 2.4s | Git commit |
+| `GET /projects/{project_key}/artifacts` | 65ms | 110ms | 160ms | File listing |
+| `GET /projects/{project_key}/artifacts/{artifact_path}` | 90ms | 150ms | 220ms | File read + markdown |
+| `POST /projects/{project_key}/raid` | 1.8s | 2.3s | 2.9s | JSON write + git commit |
+| `GET /projects/{project_key}/raid` | 55ms | 95ms | 140ms | JSON read |
 
 **Performance Factors:**
 


### PR DESCRIPTION
## Goal / Context

Docs-only quality pass to normalize endpoint placeholder naming in tutorials and reduce ambiguity (`{key}`, `{id}`, `{name}`) in API examples.

## Acceptance Criteria

- [x] Endpoint placeholders are normalized to canonical names where practical (`{project_key}`, `{raid_id}`, `{artifact_path}`)
- [x] API examples remain aligned with current FastAPI routes
- [x] Changes are documentation-only

## Validation Evidence

- [x] Ran strict method+path audit across `docs/tutorials/**` against router definitions
- [x] Result: `mismatches 0`
- [x] Ran tutorial relative-link scan
- [x] Result: `missing links: 0`
- [x] Diagnostics check on touched files (only pre-existing markdown warnings in `ERROR-CATALOG.md`)

## Repo Hygiene / Safety

- [x] No changes to `projectDocs/`
- [x] No secrets/config credentials added
- [x] Only tutorial markdown updated
