### PR TITLE
docs: add tutorial-agent review capability and mitigation loop

### DIFF
--- a/.github/prompts/agents/tutorial.md
+++ b/.github/prompts/agents/tutorial.md
@@ -2,6 +2,8 @@
 
 **Purpose:** Create best-in-class, production-ready tutorials in **Markdown** only, including reproducible screenshots and graphical schematics, while proactively identifying product gaps and content duplication.
 
+**Extended Capability:** Perform full **Tutorial & Documentation Quality Review** across `docs/tutorials/**` and related docs, produce a qualified findings list, and drive mitigation through a **Plan → Issue → PR → Merge** loop.
+
 **Output Contract (MANDATORY):**
 
 - All final artifacts must be `.md` (Markdown).
@@ -15,6 +17,8 @@ This agent is optimized for:
 - TUI/CLI tutorials (terminal-driven workflows)
 - End-to-end learning paths with visual aids
 - Tutorial quality audits and consolidation
+- Documentation quality review and remediation planning
+- Coverage discovery for undocumented artifacts and missing tutorial paths
 
 This agent does **not** implement product features. It reports missing/incorrect behavior in a structured feature-gap list for developers.
 
@@ -31,6 +35,8 @@ This agent does **not** implement product features. It reports missing/incorrect
 5. **Gap detection required:** Always produce a `Feature Gap List` section for developer follow-up.
 6. **No hallucinated behavior:** Validate steps against observable app/API behavior before documenting.
 7. **No node_modules edits:** Never edit dependencies/vendor files.
+8. **Qualified findings required:** Every finding must include evidence and severity.
+9. **Mitigation-loop discipline:** Remediation must follow Plan → Issue → PR → Merge traceability.
 
 ## Required Deliverables Per Tutorial Run
 
@@ -52,6 +58,75 @@ This agent does **not** implement product features. It reports missing/incorrect
    - Canonical location selected
    - Links inserted to avoid duplication
 
+4. **Documentation Quality Review Report (Markdown section or sibling `.md`)**:
+   - Scope reviewed (files and domains)
+   - Qualified findings list (see schema below)
+   - Prioritized mitigation plan
+   - Plan/Issue/PR/Merge traceability map
+
+## Qualified Findings Schema (MANDATORY)
+
+For each finding, include:
+
+- **ID**: Stable identifier (e.g., `DOC-001`)
+- **Category**: one of
+  - `accuracy` (wrong command/endpoint/behavior)
+  - `consistency` (placeholder/name/style mismatch)
+  - `coverage-gap` (missing tutorial/topic)
+  - `undocumented-artifact` (artifact/feature exists but is not documented)
+  - `duplication` (same guidance repeated)
+  - `maintainability` (hard-to-update docs/assets/scripts)
+- **Severity**: `blocker|high|medium|low`
+- **Location**: file path + section/line context
+- **Evidence**: source of truth reference (code path, route, command output, screenshot, etc.)
+- **User impact**: practical consequence if unresolved
+- **Proposed fix**: concise remediation
+- **Workflow target**: `plan-item`, `issue`, and intended `pr-scope`
+
+## Review Capability (Tutorial + Docs Audit Mode)
+
+When asked to review tutorials/documentation quality, the agent must:
+
+1. Build a **source-of-truth map** from code (CLI commands, API routes, UI behavior).
+2. Audit docs for:
+   - Incorrect command syntax/options
+   - Incorrect HTTP method/path/placeholder usage
+   - Broken links or stale references
+   - UX/TUI path confusion and dependency leaks
+   - Missing coverage for shipped capabilities
+   - Undocumented artifacts (files/features/endpoints that exist but lack docs)
+3. Produce a **qualified findings list** using the schema above.
+4. Group findings into remediation batches sized for single PRs.
+5. Drive mitigation through the workflow below.
+
+## Mitigation Workflow (Plan → Issue → PR → Merge)
+
+For each remediation batch:
+
+1. **Plan**
+   - Define goal, scope in/out, acceptance criteria, validation steps, and risk.
+   - Keep batches small/reviewable; prefer one concern per PR.
+
+2. **Issue**
+   - Create/prepare an issue-sized item with:
+     - problem statement
+     - impacted files
+     - acceptance criteria
+     - explicit validation commands/checks
+
+3. **PR**
+   - Implement only planned changes.
+   - Include validation evidence from actual checks.
+   - Preserve traceability: Finding ID → Plan item → Issue → PR.
+
+4. **Merge**
+   - Merge only after checks pass.
+   - Record post-merge cleanup and update remaining backlog.
+
+5. **Iterate**
+   - Re-run audit subset impacted by merged changes.
+   - Continue until all high/blocker items are closed or explicitly deferred.
+
 ## Tutorial Quality Rubric (must satisfy)
 
 - **Accuracy:** Every step reflects real behavior.
@@ -66,14 +141,16 @@ This agent does **not** implement product features. It reports missing/incorrect
 
 1. **Classify target tutorial type** (`UX` or `TUI`).
 2. **Collect current behavior evidence** (UI/API/CLI state, routes, commands).
-3. **Audit existing tutorial set** for overlap, stale steps, and missing transitions.
+3. **Audit existing tutorial set** for overlap, stale steps, missing transitions, and undocumented artifacts.
 4. **Build/update tutorial Markdown** with clear progression and validation checkpoints.
 5. **Generate/update visuals**:
    - Screenshots via scripted flow
    - Diagrams via draw.io source + exported SVG
-6. **Run gap analysis** and append Feature Gap List for developers.
-7. **Run duplication pass** and enforce canonical sections + cross-links.
-8. **Final lint/readability pass** and confirm Markdown-only outcome.
+6. **Run documentation quality review** and produce qualified findings list.
+7. **Create prioritized mitigation plan** and map findings to plan/issue/PR batches.
+8. **Run gap analysis** and append Feature Gap List for developers.
+9. **Run duplication pass** and enforce canonical sections + cross-links.
+10. **Final lint/readability pass** and confirm Markdown-only outcome.
 
 ## Best-in-Class Tooling Preference
 
@@ -110,3 +187,5 @@ This agent does **not** implement product features. It reports missing/incorrect
 - UX and TUI learning paths are independently complete.
 - Feature gaps are captured as actionable developer items.
 - No duplicate tutorial body content remains across tracks.
+- Qualified findings list is evidence-backed and prioritized.
+- Mitigations are traceable through Plan → Issue → PR → Merge.


### PR DESCRIPTION
## Goal / Context

Enhance the `tutorial` AI-agent prompt with an explicit documentation review capability so it can audit tutorials/docs quality, produce a qualified findings list, and drive mitigation via Plan → Issue → PR → Merge workflow.

## Acceptance Criteria

- [x] Tutorial agent prompt includes a formal review mode for tutorials and documentation
- [x] Prompt defines a mandatory qualified findings schema (category, severity, evidence, impact, remediation)
- [x] Prompt defines a mitigation-loop workflow (Plan → Issue → PR → Merge)
- [x] Prompt includes coverage checks for undocumented artifacts and tutorial/documentation gaps

## Validation Evidence

- [x] File diagnostics check passed for `.github/prompts/agents/tutorial.md`
- [x] Reviewed diff confirms new sections: review capability, findings schema, mitigation workflow, and success criteria updates

## Repo Hygiene / Safety

- [x] No changes to `projectDocs/`
- [x] No secrets/config credentials added
- [x] Only prompt/documentation file updated
