### PR TITLE
docs: apply tutorial quality backlog batch A fixes

### DIFF
--- a/docs/tutorials/VALIDATION-REPORT.md
+++ b/docs/tutorials/VALIDATION-REPORT.md
@@ -14,7 +14,7 @@ The tutorial set was refreshed to match the currently shipped surfaces:
 
 ## Verification outcomes
 
-- Stale direct CLI usage for unsupported groups was removed from tutorial guidance.
+- Stale direct CLI usage for unsupported groups was removed from primary tutorial guidance, with validation fixtures tracked for follow-up parity updates.
 - Tutorial examples now align with currently supported command and endpoint patterns.
 - Shared setup and troubleshooting guidance was updated to reduce command-surface confusion.
 

--- a/docs/tutorials/validation/expected-outputs/advanced/01-hybrid-workflow.json
+++ b/docs/tutorials/validation/expected-outputs/advanced/01-hybrid-workflow.json
@@ -15,9 +15,9 @@
       },
       {
         "step": 3,
-        "interface": "TUI",
+        "interface": "REST",
         "action": "Add RAID entry",
-        "command": "python main.py raid add --project TEST ..."
+        "command": "curl -s -X POST http://localhost:8000/projects/TEST/raid -H 'Content-Type: application/json' -d '{\"type\":\"risk\",\"title\":\"Sample risk\",\"description\":\"Initial risk entry\",\"owner\":\"PM\"}'"
       },
       {
         "step": 4,


### PR DESCRIPTION
## Goal / Context

- Implement Batch A from `docs/tutorials/DOCUMENTATION-QUALITY-BACKLOG.md`.
- Close `DOC-001` by replacing stale unsupported TUI RAID command in validation expected output.
- Close `DOC-008` by aligning validation report wording with actual fixture follow-up status.

## Acceptance Criteria

- [x] `docs/tutorials/validation/expected-outputs/advanced/01-hybrid-workflow.json` no longer references unsupported `python main.py raid add`.
- [x] Validation expected output now uses a REST RAID create example consistent with current command surface.
- [x] `docs/tutorials/VALIDATION-REPORT.md` wording no longer overstates complete stale-command removal.
- [x] Change scope remains docs-only.

## Validation Evidence

- [x] Editor diagnostics clean for touched files.
- [x] Verified no errors in:
  - `docs/tutorials/validation/expected-outputs/advanced/01-hybrid-workflow.json`
  - `docs/tutorials/VALIDATION-REPORT.md`
- [x] Git diff limited to two documentation files.

## Repo Hygiene / Safety

- [x] No code/runtime behavior changed.
- [x] No updates under `projectDocs/`.
- [x] No secrets/config credentials added.
- [x] Batch mapped to backlog findings (`DOC-001`, `DOC-008`).
