### PR TITLE
docs: add tutorial coverage for audit and command history APIs

### DIFF
--- a/docs/tutorials/advanced/03-automation-scripting.md
+++ b/docs/tutorials/advanced/03-automation-scripting.md
@@ -3,6 +3,7 @@
 Build scripts around the currently supported surfaces.
 
 ## Supported automation targets
+
 - TUI: `projects create/list/get`, `commands propose/apply`, `artifacts list/get`, `health`
 - REST: RAID CRUD + workflow state/allowed-transitions
 
@@ -23,9 +24,21 @@ python apps/tui/main.py artifacts list --project AUTO-001
 curl -s -X PATCH http://localhost:8000/projects/AUTO-001/workflow/state \
   -H "Content-Type: application/json" \
   -d '{"to_state":"executing","actor":"bot","reason":"pipeline gate passed"}' | jq .
+
+# Execute command via global commands API (versioned)
+curl -s -X POST http://localhost:8000/api/v1/commands \
+  -H "Content-Type: application/json" \
+  -d '{"project_key":"AUTO-001","command":"generate_plan","params":{}}' | jq .
+
+# List command history for a project
+curl -s "http://localhost:8000/api/v1/commands?projectKey=AUTO-001" | jq .
+
+# Get command details by ID
+curl -s http://localhost:8000/api/v1/commands/<command-id> | jq .
 ```
 
 ## CI note
+
 For new integrations, prefer `/api/v1/*` endpoints in scripts.
 
 ---

--- a/docs/tutorials/gui-basics/05-workflow-states.md
+++ b/docs/tutorials/gui-basics/05-workflow-states.md
@@ -38,6 +38,32 @@ curl -s -X PATCH http://localhost:8000/projects/TODO-001/workflow/state \
 - `/api/v1/projects/{project_key}/workflow/state`
 - `/api/v1/projects/{project_key}/workflow/allowed-transitions`
 
+## Audit operations (workflow assurance)
+
+### List audit events
+
+```bash
+curl -s "http://localhost:8000/projects/TODO-001/audit-events?limit=20" | jq .
+```
+
+### Run project audit rules
+
+```bash
+curl -s -X POST http://localhost:8000/projects/TODO-001/audit | jq .
+```
+
+### Read audit history
+
+```bash
+curl -s "http://localhost:8000/projects/TODO-001/audit/history?limit=10" | jq .
+```
+
+### Run bulk audit (all projects)
+
+```bash
+curl -s -X POST http://localhost:8000/projects/audit/bulk | jq .
+```
+
 ---
 
 **Last Updated:** 2026-02-16

--- a/docs/tutorials/tui-basics/05-full-lifecycle.md
+++ b/docs/tutorials/tui-basics/05-full-lifecycle.md
@@ -36,7 +36,27 @@ curl -s -X PATCH http://localhost:8000/projects/TODO-002/workflow/state \
   -d '{"to_state":"planning","actor":"pm","reason":"charter approved"}' | jq .
 ```
 
+## 6) Run workflow audits (REST)
+
+```bash
+# Run audit rules for the project
+curl -s -X POST http://localhost:8000/projects/TODO-002/audit | jq .
+
+# Read recent audit events
+curl -s "http://localhost:8000/projects/TODO-002/audit-events?limit=10" | jq .
+
+# Read audit history snapshots
+curl -s "http://localhost:8000/projects/TODO-002/audit/history?limit=5" | jq .
+```
+
+## 7) Optional: run bulk audits
+
+```bash
+curl -s -X POST http://localhost:8000/projects/audit/bulk | jq .
+```
+
 ## Notes
+
 - Versioned route equivalents exist under `/api/v1/projects/...`.
 
 ---


### PR DESCRIPTION
## Goal / Context

- Implement Batch B from `docs/tutorials/DOCUMENTATION-QUALITY-BACKLOG.md`.
- Close `DOC-006` by documenting workflow audit endpoints in existing lifecycle/workflow tutorials.
- Close `DOC-007` by documenting global command execution/history endpoints in automation tutorial.

## Acceptance Criteria

- [x] Add audit endpoint usage (`/audit`, `/audit-events`, `/audit/history`, `/projects/audit/bulk`) to workflow tutorials.
- [x] Add global command API examples (`POST/GET /api/v1/commands`, `GET /api/v1/commands/{command_id}`) to automation tutorial.
- [x] Keep changes additive and docs-only.
- [x] Preserve existing tutorial command surface guidance.

## Validation Evidence

- [x] Editor diagnostics clean for:
  - `docs/tutorials/gui-basics/05-workflow-states.md`
  - `docs/tutorials/tui-basics/05-full-lifecycle.md`
  - `docs/tutorials/advanced/03-automation-scripting.md`
- [x] Markdown lint spacing issues resolved in touched files.
- [x] Git diff limited to tutorial markdown files.

## Repo Hygiene / Safety

- [x] No runtime/API code changed.
- [x] No updates under `projectDocs/`.
- [x] No secrets/config credentials added.
- [x] Traceable to backlog findings (`DOC-006`, `DOC-007`).
