### PR TITLE
docs: add templates and blueprints API tutorial coverage

### DIFF
--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -36,6 +36,11 @@ This tutorial set reflects the **current** command surface as of 2026-02-16.
 3. [GUI Commands and Proposals](gui-basics/03-commands-and-proposals.md)
 4. [Documentation Quality Backlog](DOCUMENTATION-QUALITY-BACKLOG.md)
 
+## Advanced API tutorials
+
+1. [Templates API](advanced/04-templates-api.md)
+2. [Blueprints API](advanced/05-blueprints-api.md)
+
 ## Visual learning assets (screenshots + diagrams)
 
 - Guide: [Visual Learning Guide](visual-learning-guide.md)

--- a/docs/tutorials/advanced/04-templates-api.md
+++ b/docs/tutorials/advanced/04-templates-api.md
@@ -1,0 +1,75 @@
+# Templates API (Advanced)
+
+Manage reusable artifact templates through the versioned API.
+
+## Endpoint summary
+
+- `POST /api/v1/templates`
+- `GET /api/v1/templates`
+- `GET /api/v1/templates/{template_id}`
+- `PUT /api/v1/templates/{template_id}`
+- `DELETE /api/v1/templates/{template_id}`
+
+Legacy equivalents are also available under `/templates/*`, but new integrations should prefer `/api/v1/*`.
+
+## 1) Create a template
+
+```bash
+curl -s -X POST http://localhost:8000/api/v1/templates \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Project Charter Template",
+    "description": "Baseline charter structure for early planning.",
+    "schema": {
+      "type": "object",
+      "properties": {
+        "project_name": { "type": "string" },
+        "sponsor": { "type": "string" }
+      },
+      "required": ["project_name", "sponsor"]
+    },
+    "markdown_template": "# {{ project_name }}\\n\\nSponsor: {{ sponsor }}",
+    "artifact_type": "pmp",
+    "version": "1.0.0"
+  }' | jq .
+```
+
+## 2) List templates
+
+```bash
+curl -s http://localhost:8000/api/v1/templates | jq .
+```
+
+## 3) Get template by ID
+
+```bash
+curl -s http://localhost:8000/api/v1/templates/<template-id> | jq .
+```
+
+## 4) Update template
+
+```bash
+curl -s -X PUT http://localhost:8000/api/v1/templates/<template-id> \
+  -H "Content-Type: application/json" \
+  -d '{
+    "description": "Updated charter template for gated planning reviews.",
+    "version": "1.1.0"
+  }' | jq .
+```
+
+## 5) Delete template
+
+```bash
+curl -i -X DELETE http://localhost:8000/api/v1/templates/<template-id>
+```
+
+Expected success status: `204 No Content`.
+
+## Notes
+
+- Allowed `artifact_type` values are: `pmp`, `raid`, `blueprint`, `proposal`, `report`.
+- `schema` must include at least a top-level `type` key.
+
+---
+
+**Last Updated:** 2026-02-17

--- a/docs/tutorials/advanced/05-blueprints-api.md
+++ b/docs/tutorials/advanced/05-blueprints-api.md
@@ -1,0 +1,68 @@
+# Blueprints API (Advanced)
+
+Manage blueprint definitions that group required/optional templates and workflow requirements.
+
+## Endpoint summary
+
+- `POST /api/v1/blueprints`
+- `GET /api/v1/blueprints`
+- `GET /api/v1/blueprints/{blueprint_id}`
+- `PUT /api/v1/blueprints/{blueprint_id}`
+- `DELETE /api/v1/blueprints/{blueprint_id}`
+
+Legacy equivalents also exist under `/blueprints/*`, but `/api/v1/*` is preferred for new automation.
+
+## 1) Create a blueprint
+
+```bash
+curl -s -X POST http://localhost:8000/api/v1/blueprints \
+  -H "Content-Type: application/json" \
+  -d '{
+    "id": "iso-core-v1",
+    "name": "ISO Core Blueprint",
+    "description": "Core planning + control artifact set.",
+    "required_templates": ["project-charter", "project-plan"],
+    "optional_templates": ["risk-register"],
+    "workflow_requirements": ["initiating", "planning", "executing"]
+  }' | jq .
+```
+
+## 2) List blueprints
+
+```bash
+curl -s http://localhost:8000/api/v1/blueprints | jq .
+```
+
+## 3) Get blueprint by ID
+
+```bash
+curl -s http://localhost:8000/api/v1/blueprints/iso-core-v1 | jq .
+```
+
+## 4) Update blueprint
+
+```bash
+curl -s -X PUT http://localhost:8000/api/v1/blueprints/iso-core-v1 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "description": "Core planning + control artifact set (updated).",
+    "optional_templates": ["risk-register", "decision-log"]
+  }' | jq .
+```
+
+## 5) Delete blueprint
+
+```bash
+curl -i -X DELETE http://localhost:8000/api/v1/blueprints/iso-core-v1
+```
+
+Expected success status: `204 No Content`.
+
+## Notes
+
+- Blueprint IDs are client-provided at creation time.
+- Use template IDs in `required_templates` and `optional_templates`.
+
+---
+
+**Last Updated:** 2026-02-17


### PR DESCRIPTION
## Goal / Context

- Implement Batch C from `docs/tutorials/DOCUMENTATION-QUALITY-BACKLOG.md`.
- Close `DOC-002` by adding a templates API tutorial with CRUD examples and validated payload shape.
- Close `DOC-003` by adding a blueprints API tutorial with CRUD examples and validated payload shape.

## Acceptance Criteria

- [x] Add `docs/tutorials/advanced/04-templates-api.md` covering create/list/get/update/delete.
- [x] Add `docs/tutorials/advanced/05-blueprints-api.md` covering create/list/get/update/delete.
- [x] Include versioned endpoint usage under `/api/v1/*` with practical curl examples.
- [x] Add discoverability links in `docs/tutorials/README.md`.

## Validation Evidence

- [x] Editor diagnostics show no errors for:
  - `docs/tutorials/advanced/04-templates-api.md`
  - `docs/tutorials/advanced/05-blueprints-api.md`
  - `docs/tutorials/README.md`
- [x] Payload examples align with current domain models (`TemplateCreate`, `BlueprintCreate`).
- [x] Change scope is docs-only.

## Repo Hygiene / Safety

- [x] No runtime/API code changed.
- [x] No updates under `projectDocs/`.
- [x] No secrets/config credentials added.
- [x] Backlog traceability: `DOC-002`, `DOC-003`.
