### PR TITLE
docs: add advanced skills and governance API tutorials

### DIFF
--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -40,6 +40,8 @@ This tutorial set reflects the **current** command surface as of 2026-02-16.
 
 1. [Templates API](advanced/04-templates-api.md)
 2. [Blueprints API](advanced/05-blueprints-api.md)
+3. [Agent Skills API](advanced/06-agent-skills-api.md)
+4. [Governance API](advanced/07-governance-api.md)
 
 ## Visual learning assets (screenshots + diagrams)
 

--- a/docs/tutorials/advanced/06-agent-skills-api.md
+++ b/docs/tutorials/advanced/06-agent-skills-api.md
@@ -1,0 +1,83 @@
+# Agent Skills API (Advanced)
+
+Use cognitive skills endpoints for memory, planning, and learning flows.
+
+## Endpoint summary
+
+Base path (versioned): `/api/v1/agents/{agent_id}`
+
+- `GET /skills`
+- `GET /skills/memory?memory_type=<short_term|long_term>`
+- `POST /skills/memory`
+- `POST /skills/plan`
+- `POST /skills/learn`
+- `GET /skills/learn/summary`
+
+Legacy equivalents also exist under `/agents/{agent_id}/skills*`, but `/api/v1/*` is preferred.
+
+## 1) List available skills
+
+```bash
+curl -s http://localhost:8000/api/v1/agents/demo-agent/skills | jq .
+```
+
+## 2) Store memory
+
+```bash
+curl -s -X POST http://localhost:8000/api/v1/agents/demo-agent/skills/memory \
+  -H "Content-Type: application/json" \
+  -d '{
+    "memory_type": "short_term",
+    "data": {
+      "project_key": "AUTO-001",
+      "last_action": "generate_plan"
+    }
+  }' | jq .
+```
+
+## 3) Read memory
+
+```bash
+curl -s "http://localhost:8000/api/v1/agents/demo-agent/skills/memory?memory_type=short_term" | jq .
+```
+
+## 4) Create a plan
+
+```bash
+curl -s -X POST http://localhost:8000/api/v1/agents/demo-agent/skills/plan \
+  -H "Content-Type: application/json" \
+  -d '{
+    "goal": "Prepare governance baseline for release",
+    "constraints": ["2-day timeline", "no schema changes"],
+    "context": {"project_key": "AUTO-001"}
+  }' | jq .
+```
+
+## 5) Log learning event
+
+```bash
+curl -s -X POST http://localhost:8000/api/v1/agents/demo-agent/skills/learn \
+  -H "Content-Type: application/json" \
+  -d '{
+    "context": "CI pipeline review",
+    "action": "Added command-history checks",
+    "outcome": "Reduced regressions",
+    "feedback": "Keep checks in smoke suite",
+    "tags": ["ci", "quality"]
+  }' | jq .
+```
+
+## 6) Read learning summary
+
+```bash
+curl -s http://localhost:8000/api/v1/agents/demo-agent/skills/learn/summary | jq .
+```
+
+## Notes
+
+- `agent_id` is a routing key for agent context.
+- For memory calls, `memory_type` should be `short_term` or `long_term`.
+
+---
+
+**Last Updated:** 2026-02-17

--- a/docs/tutorials/advanced/07-governance-api.md
+++ b/docs/tutorials/advanced/07-governance-api.md
@@ -1,0 +1,95 @@
+# Governance API (Advanced)
+
+Use governance endpoints to manage metadata, decision logs, and decision-to-RAID traceability.
+
+## Endpoint summary
+
+Project-scoped base path (versioned): `/api/v1/projects/{project_key}/governance`
+
+- `GET /metadata`
+- `POST /metadata`
+- `PUT /metadata`
+- `GET /decisions`
+- `GET /decisions/{decision_id}`
+- `POST /decisions`
+- `POST /decisions/{decision_id}/link-raid/{raid_id}`
+
+Legacy equivalents also exist under `/projects/{project_key}/governance/*`.
+
+## 1) Create governance metadata
+
+```bash
+curl -s -X POST http://localhost:8000/api/v1/projects/GOV-001/governance/metadata \
+  -H "Content-Type: application/json" \
+  -d '{
+    "objectives": ["Deliver MVP", "Maintain audit traceability"],
+    "scope": "Governance baseline for release train",
+    "stakeholders": [
+      {"name": "Alice", "role": "Sponsor", "responsibilities": "Approve stage gates"},
+      {"name": "Bob", "role": "PM", "responsibilities": "Coordinate execution"}
+    ],
+    "decision_rights": {
+      "budget_change": "Sponsor",
+      "scope_change": "Steering Committee"
+    },
+    "stage_gates": [
+      {"name": "Planning Complete", "criteria": ["Plan approved", "RAID initialized"]}
+    ],
+    "approvals": [
+      {"name": "Go/No-Go", "authority": "Sponsor"}
+    ]
+  }' | jq .
+```
+
+## 2) Read and update metadata
+
+```bash
+# Read metadata
+curl -s http://localhost:8000/api/v1/projects/GOV-001/governance/metadata | jq .
+
+# Partial update
+curl -s -X PUT http://localhost:8000/api/v1/projects/GOV-001/governance/metadata \
+  -H "Content-Type: application/json" \
+  -d '{
+    "scope": "Governance baseline for release train (updated)",
+    "updated_by": "pm"
+  }' | jq .
+```
+
+## 3) Create and read decisions
+
+```bash
+# Create decision
+curl -s -X POST http://localhost:8000/api/v1/projects/GOV-001/governance/decisions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Adopt phased rollout",
+    "description": "Release by stage gate with audit checkpoints",
+    "decision_maker": "Steering Committee",
+    "rationale": "Reduce delivery risk",
+    "impact": "Longer lead time, lower failure rate",
+    "status": "approved",
+    "created_by": "pm"
+  }' | jq .
+
+# List decisions
+curl -s http://localhost:8000/api/v1/projects/GOV-001/governance/decisions | jq .
+
+# Get one decision
+curl -s http://localhost:8000/api/v1/projects/GOV-001/governance/decisions/<decision-id> | jq .
+```
+
+## 4) Link decision to RAID item
+
+```bash
+curl -s -X POST http://localhost:8000/api/v1/projects/GOV-001/governance/decisions/<decision-id>/link-raid/<raid-id> | jq .
+```
+
+## Notes
+
+- Governance endpoints require the project to exist.
+- Create metadata once; subsequent changes use `PUT /metadata`.
+
+---
+
+**Last Updated:** 2026-02-17


### PR DESCRIPTION
## Goal / Context

- Implement Batch D from `docs/tutorials/DOCUMENTATION-QUALITY-BACKLOG.md`.
- Close `DOC-004` by adding a dedicated Agent Skills API tutorial.
- Close `DOC-005` by adding a dedicated Governance API tutorial.

## Acceptance Criteria

- [x] Add `docs/tutorials/advanced/06-agent-skills-api.md` with memory/plan/learn endpoint coverage.
- [x] Add `docs/tutorials/advanced/07-governance-api.md` with metadata + decisions + RAID-link coverage.
- [x] Add discoverability links in `docs/tutorials/README.md`.
- [x] Use versioned `/api/v1/*` examples in tutorial commands.

## Validation Evidence

- [x] Editor diagnostics show no errors for:
  - `docs/tutorials/advanced/06-agent-skills-api.md`
  - `docs/tutorials/advanced/07-governance-api.md`
  - `docs/tutorials/README.md`
- [x] Request examples align with current models and router paths.
- [x] Change scope remains docs-only.

## Repo Hygiene / Safety

- [x] No runtime/API code changed.
- [x] No updates under `projectDocs/`.
- [x] No secrets/config credentials added.
- [x] Backlog traceability: `DOC-004`, `DOC-005`.
