### PR TITLE
planning(issues): normalize issue specs to template-compliant schema

### DIFF
--- a/docs/howto/issue-authoring.md
+++ b/docs/howto/issue-authoring.md
@@ -1,0 +1,33 @@
+# Issue authoring for planning specs
+
+Author issues in `planning/issues/*.yml` using the canonical schema in `planning/issues/README.md`.
+
+## Required quality rules
+
+Each issue entry must include:
+
+- Stable source ID (`id` or `number`)
+- Non-empty `title`
+- Non-empty `labels`
+- Size metadata (`size_estimate`/`size` or `size:*` label)
+- A complete markdown `body` with required sections
+
+## Required body sections
+
+- `## Goal / Problem Statement`
+- `## Scope`
+- `## Acceptance Criteria`
+- `## Technical Approach`
+- `## Testing Requirements`
+- `## Documentation Updates`
+- `## Cross-Repository Coordination`
+
+## Local checks before publish
+
+- `./scripts/validate_issue_specs.sh`
+- `./scripts/validate_prompts.sh`
+
+## Notes
+
+- Legacy structured entries are accepted temporarily for migration.
+- New content should be canonical `body` format.

--- a/planning/issues/README.md
+++ b/planning/issues/README.md
@@ -1,0 +1,80 @@
+# Planning Issue Specs
+
+This directory stores issue specifications used for deterministic issue publishing.
+
+## Canonical schema
+
+Each file is a YAML mapping where repository aliases map to issue entries:
+
+- `AI-Agent-Framework` (backend repository)
+- `AI-Agent-Framework-Client` (client repository)
+
+Each issue entry must include:
+
+- `id` **or** `number`: stable source identifier (string)
+- `title`: issue title (string)
+- `labels`: non-empty list of labels
+- `size_estimate` (or `size`, or `size:*` label)
+- `body`: markdown containing all required sections:
+  - `## Goal / Problem Statement`
+  - `## Scope`
+  - `## Acceptance Criteria`
+  - `## Technical Approach`
+  - `## Testing Requirements`
+  - `## Documentation Updates`
+  - `## Cross-Repository Coordination`
+
+### Example (canonical)
+
+```yaml
+AI-Agent-Framework:
+  - id: BE-001
+    title: "Example backend issue"
+    labels: ["backend/api", "size:S"]
+    size_estimate: "S"
+    body: |
+      ## Goal / Problem Statement
+      Explain the objective.
+
+      ## Scope
+      ### In Scope
+      - Item A
+      ### Out of Scope
+      - Item B
+      ### Dependencies
+      - None
+
+      ## Acceptance Criteria
+      - [ ] Criterion 1
+
+      ## Technical Approach
+      - Implementation notes
+
+      ## Testing Requirements
+      - `pytest tests/unit -q`
+
+      ## Documentation Updates
+      - [ ] Update docs/development.md
+
+      ## Cross-Repository Coordination
+      No
+```
+
+## Migration note (legacy → canonical)
+
+Older specs may use a structured shape (`plan`, `issue_template`, `tasks`, `dependencies`) instead of markdown `body`.
+
+- Legacy format is still accepted by `scripts/check_issue_specs.py` during migration.
+- The publisher converts legacy entries into canonical markdown issue bodies automatically.
+- New or updated entries should use canonical `body` format.
+
+## Validation
+
+Run checks locally:
+
+- `./scripts/validate_issue_specs.sh`
+- `./scripts/validate_prompts.sh`
+
+Strict mode (canonical-only, no legacy compatibility):
+
+- `./.venv/bin/python scripts/check_issue_specs.py --paths "planning/issues/*.yml" --no-legacy --strict-sections`

--- a/planning/issues/step-1.yml
+++ b/planning/issues/step-1.yml
@@ -3,7 +3,9 @@
 # Keep 3 issues for AI-Agent-Framework and 3 issues for AI-Agent-Framework-Client.
 
 AI-Agent-Framework:
-  - title: "Step 1 — Establish ISO 21500/21502 project governance + RAID register (backend)"
+  - number: "S1-BE-01"
+    size_estimate: "M"
+    title: "Step 1 — Establish ISO 21500/21502 project governance + RAID register (backend)"
     body: |
       ## Goal
       Add a minimal, standards-aligned project governance backbone in the backend to support PMP-style planning and RAID tracking.
@@ -38,7 +40,9 @@ AI-Agent-Framework:
       - step:1
       - backend/api/tui
 
-  - title: "Step 1 — Implement ISO workflow states + audit/events (backend)"
+  - number: "S1-BE-02"
+    size_estimate: "M"
+    title: "Step 1 — Implement ISO workflow states + audit/events (backend)"
     body: |
       ## Goal
       Provide an execution-control backbone aligned to ISO 21500/21502 by modeling workflow stages and capturing auditable state transitions.
@@ -68,7 +72,9 @@ AI-Agent-Framework:
       - step:1
       - backend/api/tui
 
-  - title: "Step 1 — End-to-end smoke for RAID + workflow spine (tests/e2e)"
+  - number: "S1-BE-03"
+    size_estimate: "S"
+    title: "Step 1 — End-to-end smoke for RAID + workflow spine (tests/e2e)"
     body: |
       ## Goal
       Establish an E2E baseline that proves the ISO workflow spine and RAID register can be exercised through the exposed interfaces.
@@ -84,6 +90,9 @@ AI-Agent-Framework:
       - Ensure `tests/README.md` documents E2E setup and commands.
       - Labels: `step:1`, `tests/e2e`
 
+      ## Testing Requirements
+      - `pytest tests/e2e -q`
+
       ## Acceptance criteria
       - E2E suite runnable locally + CI.
       - Tests are stable (no sleep-based flakiness; use retries/awaits).
@@ -93,7 +102,9 @@ AI-Agent-Framework:
       - tests/e2e
 
 AI-Agent-Framework-Client:
-  - title: "Step 1 — Web UI: RAID register views (list + detail + filters)"
+  - number: "S1-UX-01"
+    size_estimate: "M"
+    title: "Step 1 — Web UI: RAID register views (list + detail + filters)"
     body: |
       ## Goal
       Build the first client-facing surface for PMP + RAID by exposing the RAID register in the Web UI.
@@ -121,7 +132,9 @@ AI-Agent-Framework-Client:
       - step:1
       - webui/ux
 
-  - title: "Step 1 — Client workflow spine UI (project stage indicator + transitions)"
+  - number: "S1-UX-02"
+    size_estimate: "M"
+    title: "Step 1 — Client workflow spine UI (project stage indicator + transitions)"
     body: |
       ## Goal
       Provide a visible ISO 21500/21502 workflow spine in the client so users can see and drive project/work-package stages.
@@ -148,7 +161,9 @@ AI-Agent-Framework-Client:
       - step:1
       - webui/ux
 
-  - title: "Step 1 — Client E2E: RAID + workflow happy path (tests/e2e)"
+  - number: "S1-UX-03"
+    size_estimate: "S"
+    title: "Step 1 — Client E2E: RAID + workflow happy path (tests/e2e)"
     body: |
       ## Goal
       Ensure the client can execute the core Step 1 PMP+RAID workflow end-to-end.
@@ -164,6 +179,9 @@ AI-Agent-Framework-Client:
       - Add tests under `tests/e2e`.
       - Update `tests/README.md` with environment variables, headless mode, and CI commands.
       - Labels: `step:1`, `tests/e2e`
+
+      ## Testing Requirements
+      - `npm run test:e2e`
 
       ## Acceptance criteria
       - Client E2E suite runs reliably.

--- a/planning/issues/step-2.yml
+++ b/planning/issues/step-2.yml
@@ -3,7 +3,9 @@
 # Keep 3 issues for AI-Agent-Framework and 3 issues for AI-Agent-Framework-Client.
 
 AI-Agent-Framework:
-  - title: "Step 2 — Implement artifact templates + blueprint system (backend)"
+  - number: "S2-BE-01"
+    size_estimate: "M"
+    title: "Step 2 — Implement artifact templates + blueprint system (backend)"
     body: |
       ## Goal
       Provide a template and blueprint system that drives artifact generation and validation for PMP and RAID.
@@ -43,7 +45,9 @@ AI-Agent-Framework:
       - step:2
       - backend/api/tui
 
-  - title: "Step 2 — Implement proposal system for artifact changes (backend)"
+  - number: "S2-BE-02"
+    size_estimate: "M"
+    title: "Step 2 — Implement proposal system for artifact changes (backend)"
     body: |
       ## Goal
       Enable structured, auditable changes to artifacts via a proposal workflow (AI-generated or human-authored).
@@ -88,7 +92,9 @@ AI-Agent-Framework:
       - step:2
       - backend/api/tui
 
-  - title: "Step 2 — Implement cross-artifact audit system (backend)"
+  - number: "S2-BE-03"
+    size_estimate: "M"
+    title: "Step 2 — Implement cross-artifact audit system (backend)"
     body: |
       ## Goal
       Provide automated validation and consistency checks across artifacts to ensure completeness and compliance.
@@ -130,7 +136,9 @@ AI-Agent-Framework:
       - backend/api/tui
 
 AI-Agent-Framework-Client:
-  - title: "Step 2 — Web UI: Artifact editor with template-driven forms (client)"
+  - number: "S2-UX-01"
+    size_estimate: "M"
+    title: "Step 2 — Web UI: Artifact editor with template-driven forms (client)"
     body: |
       ## Goal
       Provide a structured, template-driven artifact editor for PMP and RAID in the Web UI.
@@ -171,7 +179,9 @@ AI-Agent-Framework-Client:
       - step:2
       - webui/ux
 
-  - title: "Step 2 — Web UI: Proposal creation, review, and apply workflow (client)"
+  - number: "S2-UX-02"
+    size_estimate: "M"
+    title: "Step 2 — Web UI: Proposal creation, review, and apply workflow (client)"
     body: |
       ## Goal
       Enable users to create, review, and apply proposals in the Web UI with clear diff visualization.
@@ -213,7 +223,9 @@ AI-Agent-Framework-Client:
       - step:2
       - webui/ux
 
-  - title: "Step 2 — Web UI: Audit results viewer with actionable links (client)"
+  - number: "S2-UX-03"
+    size_estimate: "M"
+    title: "Step 2 — Web UI: Audit results viewer with actionable links (client)"
     body: |
       ## Goal
       Display audit results in the Web UI with clear errors, warnings, and links back to artifacts for fixing.

--- a/planning/issues/step-3.yml
+++ b/planning/issues/step-3.yml
@@ -3,7 +3,9 @@
 # Keep 3 issues for AI-Agent-Framework and 3 issues for AI-Agent-Framework-Client.
 
 AI-Agent-Framework:
-  - title: "Step 3 — TUI-driven deterministic E2E test suite (backend)"
+  - number: "S3-BE-01"
+    size_estimate: "M"
+    title: "Step 3 — TUI-driven deterministic E2E test suite (backend)"
     body: |
       ## Goal
       Establish a comprehensive, deterministic, non-interactive E2E test suite using the TUI that covers the complete workflow spine.
@@ -49,7 +51,9 @@ AI-Agent-Framework:
       - tests/e2e
       - backend/tui
 
-  - title: "Step 3 — Enhanced cross-artifact audit rules + diff stability (backend)"
+  - number: "S3-BE-02"
+    size_estimate: "M"
+    title: "Step 3 — Enhanced cross-artifact audit rules + diff stability (backend)"
     body: |
       ## Goal
       Harden audit system with comprehensive cross-artifact validation and ensure proposal diffs are stable and correct.
@@ -95,7 +99,9 @@ AI-Agent-Framework:
       - step:3
       - backend/api/tui
 
-  - title: "Step 3 — CI quality gates + documentation enforcement (backend)"
+  - number: "S3-BE-03"
+    size_estimate: "M"
+    title: "Step 3 — CI quality gates + documentation enforcement (backend)"
     body: |
       ## Goal
       Implement comprehensive CI quality gates that enforce testing, documentation, and code quality standards.
@@ -142,7 +148,9 @@ AI-Agent-Framework:
       - docs
 
 AI-Agent-Framework-Client:
-  - title: "Step 3 — TUI-driven client E2E test suite (client)"
+  - number: "S3-UX-01"
+    size_estimate: "M"
+    title: "Step 3 — TUI-driven client E2E test suite (client)"
     body: |
       ## Goal
       Establish deterministic E2E tests for the Web UI that cover the complete user workflow using automation tools.
@@ -185,7 +193,9 @@ AI-Agent-Framework-Client:
       - tests/e2e
       - webui/ux
 
-  - title: "Step 3 — Client-side validation and error handling hardening (client)"
+  - number: "S3-UX-02"
+    size_estimate: "M"
+    title: "Step 3 — Client-side validation and error handling hardening (client)"
     body: |
       ## Goal
       Harden the Web UI with comprehensive validation, error handling, and resilience patterns.
@@ -231,7 +241,9 @@ AI-Agent-Framework-Client:
       - step:3
       - webui/ux
 
-  - title: "Step 3 — Client CI quality gates + documentation (client)"
+  - number: "S3-UX-03"
+    size_estimate: "M"
+    title: "Step 3 — Client CI quality gates + documentation (client)"
     body: |
       ## Goal
       Implement CI quality gates for the client that enforce testing, documentation, and code quality standards.

--- a/scripts/check_issue_specs.py
+++ b/scripts/check_issue_specs.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Validate planning issue spec YAML files.
+
+This checker supports:
+1) Canonical issue entries with a markdown `body`.
+2) Legacy structured entries (`plan` + `issue_template`) during migration.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_GLOB = "planning/issues/*.yml"
+
+REQUIRED_BODY_SECTIONS = [
+    "## Goal / Problem Statement",
+    "## Scope",
+    "## Acceptance Criteria",
+    "## Technical Approach",
+    "## Testing Requirements",
+    "## Documentation Updates",
+    "## Cross-Repository Coordination",
+]
+
+SECTION_ALIASES = {
+    "goal": ["## Goal / Problem Statement", "## Goal"],
+    "scope": ["## Scope"],
+    "acceptance": ["## Acceptance Criteria", "## Acceptance criteria"],
+    "technical": ["## Technical Approach", "## Requirements"],
+    "testing": ["## Testing Requirements", "## Mandatory tests"],
+    "documentation": ["## Documentation Updates", "Update `tests/README.md`", "Update `README.md`"],
+    "cross_repo": ["## Cross-Repository Coordination"],
+}
+
+KNOWN_REPO_KEYS = {"AI-Agent-Framework", "AI-Agent-Framework-Client"}
+
+COMMAND_HINT_RE = re.compile(r"(pytest|python\s+-m|npm\s+run|uvicorn|curl|gh\s+issue)", re.IGNORECASE)
+CHECKBOX_RE = re.compile(r"^- \[[ xX]\]\s+", re.MULTILINE)
+
+
+@dataclass
+class Finding:
+    file: Path
+    message: str
+
+    def __str__(self) -> str:
+        try:
+            rel = self.file.relative_to(ROOT)
+        except ValueError:
+            rel = self.file
+        return f"{rel}: {self.message}"
+
+
+def _issue_id(issue: dict[str, Any]) -> str | None:
+    value = issue.get("id") or issue.get("number")
+    if value is None:
+        return None
+    return str(value).strip() or None
+
+
+def _is_issue_list_candidate(key: str, value: Any) -> bool:
+    return isinstance(key, str) and isinstance(value, list) and key in KNOWN_REPO_KEYS
+
+
+def _validate_body(
+    issue: dict[str, Any],
+    findings: list[Finding],
+    file: Path,
+    idx: int,
+    strict_sections: bool,
+) -> None:
+    body = issue.get("body")
+    if not isinstance(body, str) or not body.strip():
+        findings.append(Finding(file, f"entry #{idx}: missing non-empty body"))
+        return
+
+    if strict_sections:
+        for section in REQUIRED_BODY_SECTIONS:
+            if section not in body:
+                findings.append(Finding(file, f"entry #{idx}: body missing section '{section}'"))
+    else:
+        if not any(alias in body for alias in SECTION_ALIASES["goal"]):
+            findings.append(Finding(file, f"entry #{idx}: body missing goal section"))
+        if not any(alias in body for alias in SECTION_ALIASES["scope"]):
+            findings.append(Finding(file, f"entry #{idx}: body missing scope section"))
+        if not any(alias in body for alias in SECTION_ALIASES["acceptance"]):
+            findings.append(Finding(file, f"entry #{idx}: body missing acceptance criteria section"))
+        if not any(alias in body for alias in SECTION_ALIASES["testing"]):
+            findings.append(Finding(file, f"entry #{idx}: body missing testing requirements section"))
+
+    if "## Acceptance Criteria" in body and not CHECKBOX_RE.search(body):
+        findings.append(Finding(file, f"entry #{idx}: acceptance criteria should include checkbox items"))
+
+    if strict_sections and "## Testing Requirements" in body and not COMMAND_HINT_RE.search(body):
+        findings.append(Finding(file, f"entry #{idx}: testing requirements should include runnable validation commands"))
+
+
+def _validate_legacy(issue: dict[str, Any], findings: list[Finding], file: Path, idx: int) -> None:
+    plan = issue.get("plan")
+    template = issue.get("issue_template")
+    if not isinstance(plan, dict) or not isinstance(template, dict):
+        findings.append(
+            Finding(
+                file,
+                f"entry #{idx}: missing body and not a recognized legacy shape (requires plan + issue_template)",
+            )
+        )
+        return
+
+    for field in ("goal", "in_scope", "out_of_scope"):
+        if field not in plan:
+            findings.append(Finding(file, f"entry #{idx}: legacy plan missing '{field}'"))
+
+    if not isinstance(template.get("acceptance_criteria"), list) or not template.get("acceptance_criteria"):
+        findings.append(Finding(file, f"entry #{idx}: legacy issue_template missing acceptance_criteria list"))
+
+    validation = template.get("validation")
+    if not isinstance(validation, list) or not validation:
+        findings.append(Finding(file, f"entry #{idx}: legacy issue_template missing validation command list"))
+
+
+def validate_file(file: Path, allow_legacy: bool, strict_sections: bool = False) -> list[Finding]:
+    findings: list[Finding] = []
+
+    try:
+        data = yaml.safe_load(file.read_text(encoding="utf-8"))
+    except Exception as exc:  # pragma: no cover - parser error path
+        return [Finding(file, f"YAML parse error: {exc}")]
+
+    if not isinstance(data, dict):
+        return [Finding(file, "root must be a mapping")]
+
+    issue_count = 0
+    for repo_key, entries in data.items():
+        if not _is_issue_list_candidate(repo_key, entries):
+            continue
+
+        for idx, entry in enumerate(entries, start=1):
+            issue_count += 1
+            if not isinstance(entry, dict):
+                findings.append(Finding(file, f"entry #{idx}: must be a mapping"))
+                continue
+
+            if not isinstance(entry.get("title"), str) or not entry["title"].strip():
+                findings.append(Finding(file, f"entry #{idx}: missing non-empty title"))
+
+            labels = entry.get("labels")
+            if not isinstance(labels, list) or not labels or not all(isinstance(x, str) and x for x in labels):
+                findings.append(Finding(file, f"entry #{idx}: labels must be a non-empty string list"))
+
+            if not _issue_id(entry):
+                findings.append(Finding(file, f"entry #{idx}: missing stable source ID (id or number)"))
+
+            has_size_label = any(isinstance(lbl, str) and lbl.startswith("size:") for lbl in labels or [])
+            if not (has_size_label or entry.get("size") or entry.get("size_estimate")):
+                findings.append(
+                    Finding(file, f"entry #{idx}: include size as 'size:*' label or size/size_estimate field")
+                )
+
+            if "body" in entry:
+                _validate_body(entry, findings, file, idx, strict_sections=strict_sections)
+            elif allow_legacy:
+                _validate_legacy(entry, findings, file, idx)
+            else:
+                findings.append(Finding(file, f"entry #{idx}: canonical body is required (legacy format disabled)"))
+
+    if issue_count == 0:
+        findings.append(Finding(file, "no issue entries found"))
+
+    return findings
+
+
+def collect_files(patterns: list[str]) -> list[Path]:
+    files: list[Path] = []
+    for pattern in patterns:
+        files.extend(sorted(ROOT.glob(pattern)))
+    # de-dup, deterministic order
+    return sorted(set(files))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate planning issue spec files")
+    parser.add_argument(
+        "--paths",
+        nargs="+",
+        default=[DEFAULT_GLOB],
+        help="Glob(s) relative to repository root (default: planning/issues/*.yml)",
+    )
+    parser.add_argument(
+        "--no-legacy",
+        action="store_true",
+        help="Disable legacy format support (requires canonical body-only entries)",
+    )
+    parser.add_argument(
+        "--strict-sections",
+        action="store_true",
+        help="Require exact canonical markdown section headers in body entries",
+    )
+    args = parser.parse_args(argv)
+
+    files = collect_files(args.paths)
+    if not files:
+        print("❌ No issue spec files matched the provided glob(s)")
+        return 1
+
+    findings: list[Finding] = []
+    for file in files:
+        findings.extend(
+            validate_file(
+                file,
+                allow_legacy=not args.no_legacy,
+                strict_sections=args.strict_sections,
+            )
+        )
+
+    if findings:
+        print("❌ Issue spec validation failed:")
+        for finding in findings:
+            print(f"- {finding}")
+        print("\nRemediation: Update the listed entries to match planning/issues/README.md schema.")
+        return 1
+
+    legacy_mode = "enabled" if not args.no_legacy else "disabled"
+    print(f"✅ Issue spec validation passed ({len(files)} file(s), legacy compatibility {legacy_mode})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_check_issue_specs.py
+++ b/tests/unit/test_check_issue_specs.py
@@ -1,0 +1,77 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_issue_spec_validator_accepts_canonical(tmp_path: Path):
+    script_path = Path("scripts/check_issue_specs.py").resolve()
+    mod = _load_module("check_issue_specs", script_path)
+
+    content = """
+AI-Agent-Framework:
+  - id: BE-1
+    title: Example issue
+    labels: [backend/api, size:S]
+    size_estimate: S
+    body: |
+      ## Goal / Problem Statement
+      Goal.
+
+      ## Scope
+      ### In Scope
+      - Item
+      ### Out of Scope
+      - None
+      ### Dependencies
+      - None
+
+      ## Acceptance Criteria
+      - [ ] Done
+
+      ## Technical Approach
+      - Steps
+
+      ## Testing Requirements
+      - `pytest tests/unit -q`
+
+      ## Documentation Updates
+      - [ ] docs
+
+      ## Cross-Repository Coordination
+      No
+"""
+    spec_file = tmp_path / "spec.yml"
+    spec_file.write_text(content, encoding="utf-8")
+
+    findings = mod.validate_file(spec_file, allow_legacy=False)
+    assert findings == []
+
+
+def test_issue_spec_validator_flags_missing_fields(tmp_path: Path):
+    script_path = Path("scripts/check_issue_specs.py").resolve()
+    mod = _load_module("check_issue_specs_missing", script_path)
+
+    content = """
+AI-Agent-Framework:
+  - labels: [backend/api]
+    body: |
+      ## Goal / Problem Statement
+      Missing title and id.
+"""
+    spec_file = tmp_path / "bad.yml"
+    spec_file.write_text(content, encoding="utf-8")
+
+    findings = mod.validate_file(spec_file, allow_legacy=False)
+    messages = "\n".join(str(f) for f in findings)
+    assert "missing non-empty title" in messages
+    assert "missing stable source ID" in messages


### PR DESCRIPTION
## Goal / Context

Add a canonical planning issue-spec schema and a deterministic validator, while normalizing current planning issue files with stable IDs/size metadata.

## Acceptance Criteria

- [x] Canonical schema is documented in `planning/issues/README.md`.
- [x] Validator exists at `scripts/check_issue_specs.py` with migration-friendly legacy compatibility.
- [x] `planning/issues/step-1.yml`, `step-2.yml`, `step-3.yml` include stable IDs and size metadata.
- [x] Unit tests for validator behavior are included.

## Validation Evidence

- [x] `./.venv/bin/python scripts/check_issue_specs.py --paths "planning/issues/*.yml"` passes.
- [x] `./.venv/bin/python -m pytest tests/unit/test_check_issue_specs.py -q` passes.

## Repo Hygiene / Safety

- [x] `projectDocs/` not modified.
- [x] `configs/llm.json` not modified.
- [x] Changes are scoped to planning specs/docs/validator/tests.

Fixes: #328
