### PR TITLE
ci(quality): enforce prompt and issue-spec quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,28 @@ on:
   pull_request:
 
 jobs:
+  process-quality:
+    name: "Process quality (prompts + issue specs)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install minimal validator dependency
+        run: python -m pip install --quiet pyyaml==6.0.1
+
+      - name: Validate prompt quality (strict)
+        run: ./scripts/validate_prompts.sh
+
+      - name: Validate planning issue specs
+        run: ./scripts/validate_issue_specs.sh
+
   backend-ci:
     runs-on: ubuntu-latest
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -95,6 +95,7 @@ Complete guide for local development of the ISO 21500 AI-Agent Framework.
    ```
 
 4. **Configure LLM (optional):**
+
    ```bash
    cp configs/llm.default.json configs/llm.json
    # Edit configs/llm.json with your settings
@@ -247,6 +248,7 @@ See **[../.github/copilot-instructions.md](../.github/copilot-instructions.md)**
 #### 2. Issue Creation
 
 - Create focused issues using [issue template](../.github/prompts/drafting-issue.md)
+- Author planning specs using [planning/issues/README.md](../planning/issues/README.md)
 - Include specific acceptance criteria and validation steps
 - Link related issues across repositories for cross-repo work
 - One issue = one PR
@@ -289,6 +291,10 @@ npm run build
 
 # Verify git status
 git status  # Ensure no unwanted files staged
+
+# Process quality gates (prompts + planning issue specs)
+./scripts/validate_prompts.sh
+./scripts/validate_issue_specs.sh
 ```
 
 #### 5. Pull Request
@@ -303,6 +309,13 @@ git status  # Ensure no unwanted files staged
 
 Backend CI enforces a PR description contract (required sections + checked acceptance criteria + checked validation evidence + hygiene checklist).
 If backend code changes under `apps/api/` and tests are not modified, CI requires explicit evidence that `pytest` was run (checked checkbox in the PR).
+CI also enforces prompt quality and planning issue-spec validation for `planning/issues/*.yml`.
+
+#### Deterministic issue publishing
+
+- Dry run: `./scripts/publish_issues.py --paths "planning/issues/*.yml"`
+- Apply: `./scripts/publish_issues.py --paths "planning/issues/*.yml" --apply`
+- Mapping output: `planning/issues/.published-map.json`
 
 #### 6. Review & Merge
 

--- a/scripts/validate_issue_specs.sh
+++ b/scripts/validate_issue_specs.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PYTHON_BIN="${ROOT_DIR}/.venv/bin/python"
+
+if [[ ! -x "${PYTHON_BIN}" ]]; then
+  PYTHON_BIN="python3"
+fi
+
+echo "[validate_issue_specs] Validating planning/issues/*.yml..."
+"${PYTHON_BIN}" "${ROOT_DIR}/scripts/check_issue_specs.py" --paths "planning/issues/*.yml"

--- a/scripts/validate_prompts.sh
+++ b/scripts/validate_prompts.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PYTHON_BIN="${ROOT_DIR}/.venv/bin/python"
+
+if [[ ! -x "${PYTHON_BIN}" ]]; then
+  PYTHON_BIN="python3"
+fi
+
+echo "[validate_prompts] Running strict prompt quality checks..."
+"${PYTHON_BIN}" "${ROOT_DIR}/scripts/check_prompt_quality.py" --strict


### PR DESCRIPTION
## Goal / Context

Enforce process quality in CI by validating prompt quality and planning issue-spec quality, and document local pre-push equivalents.

## Acceptance Criteria

- [x] CI includes a dedicated fast process-quality job.
- [x] CI fails on prompt-quality violations.
- [x] CI fails on issue-spec schema violations.
- [x] Local wrapper commands are available and documented.
- [x] Failure output points to exact file/rule from validators.

## Validation Evidence

- [x] `./scripts/validate_prompts.sh` passes.
- [x] `./scripts/validate_issue_specs.sh` passes.
- [x] CI workflow includes process-quality job invoking both scripts.

## Repo Hygiene / Safety

- [x] `projectDocs/` not modified.
- [x] `configs/llm.json` not modified.
- [x] Changes are limited to CI workflow, docs, and validation wrappers.

Fixes: #330
