### PR TITLE
[Issue #347] docs(tui): align command examples and local token workflow

### DIFF
--- a/docs/deployment/multi-component-guide.md
+++ b/docs/deployment/multi-component-guide.md
@@ -128,12 +128,12 @@ docker compose up --build
 **Step 3: Run TUI Client (Optional)**
 
 ```bash
-# Interactive TUI mode
-docker compose run tui python main.py tui
+# Show available TUI commands
+docker compose run tui python main.py --help
 
 # Direct command execution
-docker compose run tui python main.py list-projects
-docker compose run tui python main.py create-project PROJECT001 "My Project"
+docker compose run tui python main.py projects list
+docker compose run tui python main.py projects create --key PROJECT001 --name "My Project"
 ```
 
 **Step 4: Run CLI Client (Optional)**

--- a/docs/howto/README.md
+++ b/docs/howto/README.md
@@ -6,3 +6,4 @@
 - [Chat Context in Repo](chat-context-in-repo.md)
 - [Issue Authoring for Planning Specs](issue-authoring.md)
 - [Publish Planning Issues](publish-issues.md)
+- [Local Token Setup for Agent Workflows](local-agent-token-setup.md)

--- a/docs/howto/local-agent-token-setup.md
+++ b/docs/howto/local-agent-token-setup.md
@@ -1,0 +1,52 @@
+# Local Token Setup for Agent Workflows (No Repo Secrets)
+
+This guide shows how to run `scripts/work-issue.py` with a GitHub token **without storing real secrets in the repository**.
+
+## What is already provided
+
+- Local example env file: `.tmp/local-agent-env.example.sh`
+- Local runner wrapper: `.tmp/run-work-issue-local.sh`
+
+Both live in `.tmp/`, which is gitignored.
+
+## Option A: Use your existing `gh` login (recommended)
+
+If `gh auth status` shows you are logged in, the wrapper automatically uses `gh auth token` as fallback.
+
+Run:
+
+```bash
+./.tmp/run-work-issue-local.sh 347 --dry-run
+```
+
+## Option B: Use a local env file (still not committed)
+
+1. Create local-only env file:
+
+```bash
+cp .tmp/local-agent-env.example.sh .tmp/local-agent-env.sh
+```
+
+2. Edit `.tmp/local-agent-env.sh` and set one variable:
+
+- `GITHUB_TOKEN=...` or
+- `GH_TOKEN=...`
+
+3. Run:
+
+```bash
+./.tmp/run-work-issue-local.sh 347 --dry-run
+```
+
+## Verification
+
+Successful dry run should include:
+
+- `✅ Agent initialized and ready`
+- `✅ Dry run complete: initialization succeeded`
+
+## Security notes
+
+- Do **not** place real tokens in tracked files.
+- Keep secrets only in your shell environment or `.tmp/local-agent-env.sh`.
+- `.tmp/` is gitignored, so local token files are not committed.

--- a/docs/tutorials/DOCUMENTATION-QUALITY-BACKLOG.md
+++ b/docs/tutorials/DOCUMENTATION-QUALITY-BACKLOG.md
@@ -28,7 +28,7 @@
 - **Severity:** `high`
 - **Location:** `docs/tutorials/validation/expected-outputs/advanced/01-hybrid-workflow.json` (step 3 command)
 - **Evidence:**
-  - Stale expected output uses `python main.py raid add --project TEST ...`
+  - Stale expected output previously used non-existent `python main.py raid add --project TEST ...`; current fixture uses REST RAID create via `POST /projects/TEST/raid`.
   - TUI command groups in `apps/tui/main.py` include `projects|commands|artifacts|config|health` only.
   - Tutorial baseline explicitly states no `raid` or `workflow` TUI groups: `docs/tutorials/tui-basics/01-quick-start.md` line 29.
 - **User impact:** Validation artifacts can mislead users into trying unsupported TUI commands.


### PR DESCRIPTION
## Goal / Context

Align documentation command examples with the implemented TUI command surface and add secure local token setup guidance for agent workflows.

## Acceptance Criteria

- [x] No documented executable command examples in updated scope reference non-existent TUI commands.
- [x] Tutorial/planning documentation text aligns with actual TUI/API propose/apply + REST-only RAID realities.
- [x] Validation notes include where direct TUI equivalents do not exist.
- [x] Local token workflow is documented without storing real secrets in tracked files.

## Validation Evidence

- [x] `/home/sw/work/AI-Agent-Framework/.venv/bin/python -m black apps/api/` (no changes).
- [x] `/home/sw/work/AI-Agent-Framework/.venv/bin/python -m flake8 apps/api/` (pass).
- [x] `/home/sw/work/AI-Agent-Framework/.venv/bin/python -m pytest tests/e2e/tutorial/test_tui_basics.py -q --tb=short` → `9 passed, 10 skipped`.
- [x] `/home/sw/work/AI-Agent-Framework/.venv/bin/python -m pytest tests/ -q --tb=short --maxfail=1` shows one unrelated existing failure in `tests/e2e/tutorial/test_gui_basics.py::TestGUITutorial04ArtifactBrowsing::test_artifact_navigation_ui`.

## Repo Hygiene / Safety

- [x] `projectDocs/` not modified.
- [x] `configs/llm.json` not modified.
- [x] No real token values added to tracked files.
- [x] Scope limited to docs updates and docs index linking.

Fixes: #347
