### PR TITLE
[Issue #350] docs(tutorials): align CI/CD command examples with TUI/API workflow

### DIFF
--- a/docs/tutorials/examples/ci-cd/github-actions-example.yml
+++ b/docs/tutorials/examples/ci-cd/github-actions-example.yml
@@ -50,6 +50,7 @@ permissions:
 env:
   PYTHON_VERSION: '3.12'
   PROJECT_KEY: ${{ github.event.inputs.project_key || 'AUTO-DETECT' }}
+  API_BASE_URL: ${{ secrets.API_BASE_URL || 'http://localhost:8000' }}
 
 jobs:
   # Job 1: Generate project artifacts
@@ -111,8 +112,7 @@ jobs:
             echo "Creating new project: ${{ steps.project.outputs.PROJECT_KEY }}"
             python main.py projects create \
               --key "${{ steps.project.outputs.PROJECT_KEY }}" \
-              --name "${{ github.repository }}" \
-              --description "Automated project for ${{ github.repository }}"
+              --name "${{ github.repository }}"
           }
         env:
           PROJECT_DOCS_PATH: ../../projectDocs
@@ -121,13 +121,22 @@ jobs:
       
       - name: Generate project artifacts
         run: |
-          cd apps/tui
           echo "Generating artifacts for project: ${{ steps.project.outputs.PROJECT_KEY }}"
-          
-          # Generate all standard artifacts
-          python main.py artifacts generate --project "${{ steps.project.outputs.PROJECT_KEY }}" --type charter || echo "Charter generation skipped"
-          python main.py artifacts generate --project "${{ steps.project.outputs.PROJECT_KEY }}" --type plan || echo "Plan generation skipped"
-          python main.py artifacts generate --project "${{ steps.project.outputs.PROJECT_KEY }}" --type wbs || echo "WBS generation skipped"
+
+          # Use supported propose/apply workflow (no direct TUI artifacts generate command)
+          PROPOSAL_PLAN=$(curl -fsS -X POST "$API_BASE_URL/projects/${{ steps.project.outputs.PROJECT_KEY }}/commands/propose" \
+            -H "Content-Type: application/json" \
+            -d '{"command":"generate_plan"}' | jq -r '.proposal_id')
+          curl -fsS -X POST "$API_BASE_URL/projects/${{ steps.project.outputs.PROJECT_KEY }}/commands/apply" \
+            -H "Content-Type: application/json" \
+            -d "{\"proposal_id\":\"$PROPOSAL_PLAN\"}" >/dev/null
+
+          PROPOSAL_CHARTER=$(curl -fsS -X POST "$API_BASE_URL/projects/${{ steps.project.outputs.PROJECT_KEY }}/commands/propose" \
+            -H "Content-Type: application/json" \
+            -d '{"command":"generate_artifact","params":{"artifact_name":"PROJECT_CHARTER.md","artifact_type":"project_charter"}}' | jq -r '.proposal_id')
+          curl -fsS -X POST "$API_BASE_URL/projects/${{ steps.project.outputs.PROJECT_KEY }}/commands/apply" \
+            -H "Content-Type: application/json" \
+            -d "{\"proposal_id\":\"$PROPOSAL_CHARTER\"}" >/dev/null
           
           echo "Artifact generation completed"
         env:
@@ -184,10 +193,10 @@ jobs:
       
       - name: Generate RAID report
         run: |
-          cd apps/tui
-          
-          # List all projects
-          PROJECTS=$(python main.py projects list --format json | jq -r '.[].key' || echo "")
+          mkdir -p .tmp
+
+          # Use API endpoints for RAID reporting (no TUI `raid` command group exists)
+          PROJECTS=$(curl -fsS "$API_BASE_URL/projects" | jq -r '.[].key' || echo "")
           
           if [ -z "$PROJECTS" ]; then
             echo "No projects found"
@@ -196,24 +205,25 @@ jobs:
           
           # Generate report for each project
           for PROJECT in $PROJECTS; do
-            echo "=== RAID Report for $PROJECT ===" | tee -a /tmp/raid-report.txt
-            python main.py raid list --project "$PROJECT" --filter severity=High | tee -a /tmp/raid-report.txt || echo "No high-severity items"
-            echo "" | tee -a /tmp/raid-report.txt
+            echo "=== RAID Report for $PROJECT ===" | tee -a .tmp/raid-report.txt
+            curl -fsS "$API_BASE_URL/api/v1/projects/$PROJECT/raid?priority=critical" | jq '.' | tee -a .tmp/raid-report.txt || echo "No critical-priority RAID items" | tee -a .tmp/raid-report.txt
+            echo "" | tee -a .tmp/raid-report.txt
           done
         env:
           PROJECT_DOCS_PATH: ../../projectDocs
+          API_BASE_URL: ${{ env.API_BASE_URL }}
       
       - name: Upload RAID report
         uses: actions/upload-artifact@v4
         with:
           name: raid-report-${{ github.run_id }}
-          path: /tmp/raid-report.txt
+          path: .tmp/raid-report.txt
           retention-days: 30
       
       - name: Send notification (optional)
         if: secrets.SLACK_WEBHOOK_URL != ''
         run: |
-          REPORT_CONTENT=$(cat /tmp/raid-report.txt | head -100)
+          REPORT_CONTENT=$(cat .tmp/raid-report.txt | head -100)
           
           curl -X POST "${{ secrets.SLACK_WEBHOOK_URL }}" \
             -H "Content-Type: application/json" \
@@ -313,22 +323,26 @@ jobs:
           git config --global user.name "${{ secrets.GIT_USER_NAME || 'GitHub Actions Bot' }}"
           git config --global user.email "${{ secrets.GIT_USER_EMAIL || 'actions@github.com' }}"
       
-      - name: Full artifact regeneration
+      - name: Full workflow-based regeneration
         run: |
-          cd apps/tui
-          
           PROJECT_KEY="${{ github.event.inputs.project_key }}"
           
           echo "Starting full regeneration for: $PROJECT_KEY"
-          
-          # Regenerate all artifacts
-          python main.py artifacts regenerate --project "$PROJECT_KEY" --force
+
+          # No direct TUI regenerate command exists; use propose/apply workflow
+          PROPOSAL_PLAN=$(curl -fsS -X POST "$API_BASE_URL/projects/$PROJECT_KEY/commands/propose" \
+            -H "Content-Type: application/json" \
+            -d '{"command":"generate_plan"}' | jq -r '.proposal_id')
+          curl -fsS -X POST "$API_BASE_URL/projects/$PROJECT_KEY/commands/apply" \
+            -H "Content-Type: application/json" \
+            -d "{\"proposal_id\":\"$PROPOSAL_PLAN\"}" >/dev/null
           
           echo "✅ Full regeneration completed"
         env:
           PROJECT_DOCS_PATH: ../../projectDocs
           LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
           LLM_BASE_URL: ${{ secrets.LLM_BASE_URL }}
+          API_BASE_URL: ${{ env.API_BASE_URL }}
       
       - name: Commit regenerated artifacts
         run: |

--- a/docs/tutorials/examples/ci-cd/gitlab-ci-example.yml
+++ b/docs/tutorials/examples/ci-cd/gitlab-ci-example.yml
@@ -29,6 +29,7 @@ variables:
   PYTHON_VERSION: "3.12"
   PROJECT_DOCS_PATH: "$CI_PROJECT_DIR/projectDocs"
   PIP_CACHE_DIR: "$CI_PROJECT_DIR/.cache/pip"
+  API_BASE_URL: "${API_BASE_URL:-http://localhost:8000}"
   # Override with CI/CD variable: PROJECT_KEY
   PROJECT_KEY: "${PROJECT_KEY:-AUTO-DETECT}"
 
@@ -124,8 +125,7 @@ create-project:
         echo "Creating new project: $PROJECT_KEY"
         python main.py projects create \
           --key "$PROJECT_KEY" \
-          --name "$CI_PROJECT_NAME" \
-          --description "GitLab project: $CI_PROJECT_NAMESPACE/$CI_PROJECT_NAME"
+          --name "$CI_PROJECT_NAME"
         echo "✅ Project created successfully"
       fi
   environment:
@@ -146,19 +146,23 @@ generate-artifacts:
   script:
     - source project.env
     - echo "Generating artifacts for: $PROJECT_KEY"
-    - cd apps/tui
     - |
-      echo "Generating project charter..."
-      python main.py artifacts generate --project "$PROJECT_KEY" --type charter || echo "Charter skipped"
-      
-      echo "Generating project plan..."
-      python main.py artifacts generate --project "$PROJECT_KEY" --type plan || echo "Plan skipped"
-      
-      echo "Generating WBS..."
-      python main.py artifacts generate --project "$PROJECT_KEY" --type wbs || echo "WBS skipped"
-      
-      echo "Generating RAID register..."
-      python main.py artifacts generate --project "$PROJECT_KEY" --type raid || echo "RAID skipped"
+      # Use supported propose/apply workflow (no direct TUI artifacts generate command)
+      echo "Generating project plan via propose/apply..."
+      PROPOSAL_PLAN=$(curl -fsS -X POST "$API_BASE_URL/projects/$PROJECT_KEY/commands/propose" \
+        -H "Content-Type: application/json" \
+        -d '{"command":"generate_plan"}' | jq -r '.proposal_id')
+      curl -fsS -X POST "$API_BASE_URL/projects/$PROJECT_KEY/commands/apply" \
+        -H "Content-Type: application/json" \
+        -d "{\"proposal_id\":\"$PROPOSAL_PLAN\"}" >/dev/null
+
+      echo "Generating project charter via propose/apply..."
+      PROPOSAL_CHARTER=$(curl -fsS -X POST "$API_BASE_URL/projects/$PROJECT_KEY/commands/propose" \
+        -H "Content-Type: application/json" \
+        -d '{"command":"generate_artifact","params":{"artifact_name":"PROJECT_CHARTER.md","artifact_type":"project_charter"}}' | jq -r '.proposal_id')
+      curl -fsS -X POST "$API_BASE_URL/projects/$PROJECT_KEY/commands/apply" \
+        -H "Content-Type: application/json" \
+        -d "{\"proposal_id\":\"$PROPOSAL_CHARTER\"}" >/dev/null
       
       echo "✅ Artifact generation completed"
   artifacts:
@@ -183,24 +187,25 @@ raid-report:
   script:
     - source project.env
     - echo "Generating RAID report..."
-    - cd apps/tui
     - |
-      # Get all projects
-      PROJECTS=$(python main.py projects list --format json | jq -r '.[].key' 2>/dev/null || echo "$PROJECT_KEY")
-      
-      echo "=== RAID Report $(date +'%Y-%m-%d %H:%M:%S') ===" > /tmp/raid-report.txt
+      mkdir -p .tmp
+
+      # Use API endpoints for RAID reporting (no TUI `raid` command group exists)
+      PROJECTS=$(curl -fsS "$API_BASE_URL/projects" | jq -r '.[].key' 2>/dev/null || echo "$PROJECT_KEY")
+
+      echo "=== RAID Report $(date +'%Y-%m-%d %H:%M:%S') ===" > .tmp/raid-report.txt
       
       for PROJECT in $PROJECTS; do
-        echo "" >> /tmp/raid-report.txt
-        echo "--- Project: $PROJECT ---" >> /tmp/raid-report.txt
-        python main.py raid list --project "$PROJECT" --filter severity=High >> /tmp/raid-report.txt 2>&1 || echo "No RAID entries" >> /tmp/raid-report.txt
+        echo "" >> .tmp/raid-report.txt
+        echo "--- Project: $PROJECT ---" >> .tmp/raid-report.txt
+        curl -fsS "$API_BASE_URL/api/v1/projects/$PROJECT/raid?priority=critical" | jq '.' >> .tmp/raid-report.txt 2>&1 || echo "No RAID entries" >> .tmp/raid-report.txt
       done
       
-      cat /tmp/raid-report.txt
+      cat .tmp/raid-report.txt
   artifacts:
     name: "raid-report-$CI_PIPELINE_ID"
     paths:
-      - /tmp/raid-report.txt
+      - .tmp/raid-report.txt
     expire_in: 30 days
   only:
     - schedules
@@ -282,8 +287,14 @@ full-regenerate:
   script:
     - source project.env
     - echo "Starting FULL regeneration for: $PROJECT_KEY"
-    - cd apps/tui
-    - python main.py artifacts regenerate --project "$PROJECT_KEY" --force
+    - |
+      # No direct TUI regenerate command exists; use propose/apply workflow
+      PROPOSAL_PLAN=$(curl -fsS -X POST "$API_BASE_URL/projects/$PROJECT_KEY/commands/propose" \
+        -H "Content-Type: application/json" \
+        -d '{"command":"generate_plan"}' | jq -r '.proposal_id')
+      curl -fsS -X POST "$API_BASE_URL/projects/$PROJECT_KEY/commands/apply" \
+        -H "Content-Type: application/json" \
+        -d "{\"proposal_id\":\"$PROPOSAL_PLAN\"}" >/dev/null
     - echo "✅ Full regeneration completed"
   artifacts:
     name: "regenerated-artifacts-$PROJECT_KEY"
@@ -380,8 +391,14 @@ dependency-scanning:
 .parallel-template:
   stage: generate
   script:
-    - cd apps/tui
-    - python main.py artifacts generate --project "$PROJECT" --type all
+    - |
+      # Use workflow endpoint pattern for each matrix project
+      PROPOSAL_PLAN=$(curl -fsS -X POST "$API_BASE_URL/projects/$PROJECT/commands/propose" \
+        -H "Content-Type: application/json" \
+        -d '{"command":"generate_plan"}' | jq -r '.proposal_id')
+      curl -fsS -X POST "$API_BASE_URL/projects/$PROJECT/commands/apply" \
+        -H "Content-Type: application/json" \
+        -d "{\"proposal_id\":\"$PROPOSAL_PLAN\"}" >/dev/null
   parallel:
     matrix:
       - PROJECT: ["PROJ-A", "PROJ-B", "PROJ-C"]


### PR DESCRIPTION
## Goal / Context
Fixes: #350

Remove stale CI/CD tutorial command examples that reference non-existent TUI commands or unsupported flags. Keep this docs-only and align examples to the current `projects` + `commands propose/apply` workflow and API-based RAID reporting where no direct TUI command exists.

## Acceptance Criteria
- [x] No CI/CD tutorial examples use non-existent TUI commands (`python main.py raid ...`, `python main.py artifacts generate ...`, `python main.py artifacts regenerate ...`).
- [x] No CI/CD tutorial examples use unsupported options (`projects create --description`, `projects list --format json`).
- [x] CI/CD examples now use supported propose/apply or API endpoints where direct TUI equivalents do not exist.

## Validation Evidence
- [x] Ran stale-command scan:
  - `rg -n "python main\.py (raid|artifacts (generate|regenerate)|projects list --format|projects create .*--description)" docs/tutorials/examples/ci-cd -g '*.yml' -g '*.md'`
  - Result: no matches (exit code 1 from `rg` indicates no findings).
- [x] Ran tutorial test suite:
  - `/.venv/bin/python -m pytest tests/e2e/tutorial -q`
  - Result: `1 failed, 18 passed, 23 skipped`.
  - Failure: `tests/e2e/tutorial/test_gui_basics.py::TestGUITutorial04ArtifactBrowsing::test_artifact_navigation_ui` (pre-existing GUI assertion, unrelated to docs-only changes).

## Repo Hygiene / Safety
- [x] Changed files are docs-only (`docs/tutorials/examples/ci-cd/github-actions-example.yml`, `docs/tutorials/examples/ci-cd/gitlab-ci-example.yml`).
- [x] No changes under `projectDocs/` or `configs/llm.json`.
- [x] No backend/frontend runtime code paths changed.
