### PR TITLE
[Issue #363] fix(testing): deterministic and usable coverage runner

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -102,7 +102,7 @@ jobs:
       
       - name: Run tests with coverage
         run: |
-          pytest tests/ --cov=apps/api --cov=apps/tui --cov-report=term-missing --cov-report=json
+          bash scripts/run_pytest_coverage.sh --ci
       
       - name: Check coverage diff
         run: |

--- a/agents/tools.py
+++ b/agents/tools.py
@@ -587,7 +587,7 @@ def analyze_coverage_impact(
             return json.dumps(
                 {
                     "error": "Failed to generate coverage report",
-                    "suggestion": "Run: pytest tests/ --cov=apps/api --cov=apps/tui --cov-report=json",
+                    "suggestion": "Run: bash scripts/run_pytest_coverage.sh --local-stable",
                 },
                 indent=2,
             )

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -45,10 +45,15 @@ TERM=xterm-256color pytest tests/e2e/ -v
 
 **How to pass**:
 ```bash
-pytest tests/ --cov=apps/api --cov=apps/tui --cov-report=term-missing
+bash scripts/run_pytest_coverage.sh --ci
 python scripts/coverage_diff.py origin/main HEAD
 ```
 
+For local troubleshooting (deterministic core suites), use:
+
+```bash
+bash scripts/run_pytest_coverage.sh --local-stable
+```
 **Failure remediation**:
 - Identify uncovered lines in coverage report
 - Add tests to cover new/changed code

--- a/scripts/ci_backend.sh
+++ b/scripts/ci_backend.sh
@@ -52,7 +52,7 @@ run_gate 1 "All Tests Pass" "pytest tests/ -v --tb=short -q"
 # Gate 2: Coverage Threshold
 run_gate 2 "Coverage Threshold (80%+)" "
     pip install -q pytest-cov > /dev/null 2>&1 &&
-    pytest tests/ --cov=apps/api --cov=apps/tui --cov-report=term-missing -q &&
+    bash scripts/run_pytest_coverage.sh --ci -q &&
     python scripts/coverage_diff.py origin/main HEAD
 "
 

--- a/scripts/run_pytest_coverage.sh
+++ b/scripts/run_pytest_coverage.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$PROJECT_ROOT"
+
+export PYTHONPATH="$PROJECT_ROOT/apps/api:$PROJECT_ROOT/apps/tui:$PROJECT_ROOT${PYTHONPATH:+:$PYTHONPATH}"
+
+LOCK_DIR=".tmp/coverage"
+LOCK_FILE="$LOCK_DIR/pytest-cov.lock"
+mkdir -p "$LOCK_DIR"
+
+if ! command -v flock >/dev/null 2>&1; then
+    echo "❌ flock is required for deterministic coverage execution" >&2
+    exit 2
+fi
+
+MODE="full"
+USER_ARGS=()
+
+print_help() {
+    cat <<'EOF'
+Usage: bash scripts/run_pytest_coverage.sh [mode] [pytest_args...]
+
+Modes:
+    --full           Run full tests/ with coverage (default)
+    --ci             Alias for --full (explicit CI intent)
+    --local-stable   Run deterministic core suites (unit/integration/agents/ci)
+  --help           Show this help message
+
+Examples:
+  bash scripts/run_pytest_coverage.sh --ci -q
+  bash scripts/run_pytest_coverage.sh --local-stable -q
+  bash scripts/run_pytest_coverage.sh --full -k "health"
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --full)
+            MODE="full"
+            shift
+            ;;
+        --ci)
+            MODE="ci"
+            shift
+            ;;
+        --local-stable)
+            MODE="local-stable"
+            shift
+            ;;
+        --help|-h)
+            print_help
+            exit 0
+            ;;
+        *)
+            USER_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+PYTHON_BIN="python"
+if [ -x "$PROJECT_ROOT/.venv/bin/python" ]; then
+    PYTHON_BIN="$PROJECT_ROOT/.venv/bin/python"
+fi
+
+SHIM_DIR="$LOCK_DIR/bin"
+mkdir -p "$SHIM_DIR"
+cat > "$SHIM_DIR/python" <<EOF
+#!/usr/bin/env bash
+exec "$PYTHON_BIN" "\$@"
+EOF
+chmod +x "$SHIM_DIR/python"
+export PATH="$SHIM_DIR:$PATH"
+
+echo "🔒 Acquiring coverage lock: $LOCK_FILE"
+exec 9>"$LOCK_FILE"
+flock 9
+
+echo "🧹 Cleaning stale coverage shards"
+rm -f .coverage .coverage.*
+
+export COVERAGE_FILE="$LOCK_DIR/.coverage"
+
+echo "🧪 Running pytest with coverage"
+echo "🐍 Using interpreter: $PYTHON_BIN"
+echo "🧭 Mode: $MODE"
+
+PYTEST_ARGS=(tests/ --cov=apps/api --cov=apps/tui --cov-report=term-missing --cov-report=json)
+
+if [[ "$MODE" == "local-stable" ]]; then
+    PYTEST_ARGS=(
+        tests/unit/
+        tests/integration/
+        tests/agents/
+        tests/ci/
+        --cov=apps/api
+        --cov=apps/tui
+        --cov-report=term-missing
+        --cov-report=json
+    )
+fi
+
+PYTEST_ARGS+=("${USER_ARGS[@]}")
+
+"$PYTHON_BIN" -m pytest "${PYTEST_ARGS[@]}"
+
+echo "✅ Coverage run completed (coverage.json updated)"

--- a/tests/README.md
+++ b/tests/README.md
@@ -74,8 +74,14 @@ pytest tests/e2e -k step2
 ### Coverage
 
 ```bash
-pytest tests/ --cov=apps/api --cov=apps/tui --cov-report=term-missing --cov-report=json
+bash scripts/run_pytest_coverage.sh --ci
 python scripts/coverage_diff.py origin/main HEAD
+```
+
+Local stable run (deterministic core suites only):
+
+```bash
+bash scripts/run_pytest_coverage.sh --local-stable
 ```
 
 ## CI notes


### PR DESCRIPTION
## Goal / Context
Fixes: #363

Make coverage execution deterministic and more usable for local developers while keeping CI behavior strict.

## Acceptance Criteria
- [x] Add a canonical coverage runner script with lock-based serialization.
- [x] Keep CI path strict and explicit.
- [x] Add local-stable mode for deterministic local validation.
- [x] Update docs/tool guidance to use canonical script.

## What Changed
- Added `scripts/run_pytest_coverage.sh`:
  - File lock via `flock` to avoid concurrent coverage writer contention.
  - Cleans stale coverage shards before run.
  - Adds local `python` shim so subprocess calls to `python` resolve consistently.
  - Modes:
    - `--ci` / `--full` (strict)
    - `--local-stable` (deterministic core suites)
- Updated CI Gate 2 to call `bash scripts/run_pytest_coverage.sh --ci`.
- Updated local CI simulator Gate 2 to call `bash scripts/run_pytest_coverage.sh --ci -q`.
- Updated docs and agent suggestion to canonical runner usage.

## Validation Evidence
- [x] `bash scripts/run_pytest_coverage.sh --help`
- [x] `bash scripts/run_pytest_coverage.sh --local-stable -q`
  - Result: pass (`751/765` depending on selection snapshots, no flake exit behavior)
- [x] `python scripts/coverage_diff.py origin/main HEAD`
  - Result: `No Python files changed in apps/ - coverage check passed`
- [x] `bash scripts/run_pytest_coverage.sh --ci -q`
  - Result: strict mode remains strict in local env (expected failure on environment-dependent GUI/TUI scenarios)

## Repo Hygiene / Safety
- [x] No changes under `projectDocs/` or `configs/llm.json`.
- [x] Changes are script/workflow/docs/tooling only.
- [x] CI semantics preserved; local ergonomics improved.
