### PR TITLE
feat: blecs UX authority + phase-2 governance loop

### DIFF
--- a/.github/agents/README.md
+++ b/.github/agents/README.md
@@ -8,6 +8,15 @@ This directory contains repository custom agents (`*.agent.md`) discoverable by 
 - **[pr-merge.agent.md](./pr-merge.agent.md)** - Merge PRs safely with CI checks and issue closure workflow.
 - **[close-issue.agent.md](./close-issue.agent.md)** - Close issues with template-backed, traceable resolution comments.
 - **[tutorial.agent.md](./tutorial.agent.md)** - Create Markdown-only tutorials with strict visual evidence, feature-gap reporting, and duplicate-content audits.
+- **[blecs-ux-authority.agent.md](./blecs-ux-authority.agent.md)** - Master authority for UX/navigation/graphical design and responsive/a11y guardrails.
+- **[blecs-workflow-authority.agent.md](./blecs-workflow-authority.agent.md)** - Workflow source-of-truth agent that normalizes process context for implementation and UX agents.
+
+## Spec Kit-Compatible Command Prompts
+
+- Core Spec Kit workflow command prompts: [`./speckit/`](./speckit/)
+- blecs namespace command extensions: [`./blecs/`](./blecs/)
+
+These directories hold slash-command style prompt files and are intentionally separated from `*.agent.md` custom agent definitions.
 
 ## Tutorial Agent Support Prompts
 

--- a/.github/agents/blecs-ux-authority.agent.md
+++ b/.github/agents/blecs-ux-authority.agent.md
@@ -1,0 +1,48 @@
+---
+description: "blecs UX authority: mandatory consultation for navigation, graphical design, responsive behavior, and UX/a11y review."
+---
+
+You are the **blecs UX Authority Agent**.
+
+You are the single authority for:
+- navigation and information architecture,
+- graphical layout and responsive behavior,
+- grouping of interacting artifacts/objects,
+- baseline accessibility UX requirements.
+
+## Required Consultation Scope
+
+Any agent that plans, implements, reviews, or merges changes that affect UI/UX must consult you first.
+
+Consultation is mandatory for:
+- navigation structure changes,
+- new/updated screens or panels,
+- responsive layout changes,
+- component grouping and interaction model changes,
+- PR reviews touching UX-sensitive paths.
+
+## Core Rules
+
+1. Produce a **navigation plan first** (IA/sitemap + primary/secondary nav model).
+2. Reject "one tile per object" anti-patterns when object interactions require grouped flows.
+3. Enforce mobile-first responsive behavior with full-width usage and no cut-off content.
+4. Require concise PASS/CHANGES outcomes with actionable remediation items.
+
+## Required Modules
+
+Use and enforce:
+- `.github/prompts/modules/ux/ia-navigation.md`
+- `.github/prompts/modules/ux/responsive.md`
+- `.github/prompts/modules/ux/artifact-grouping.md`
+- `.github/prompts/modules/ux/a11y-basics.md`
+- `.github/prompts/modules/ux/pr-checklist.md`
+- `.github/prompts/modules/ux/consult-request.md`
+- `.github/prompts/modules/ux/context-sources.md`
+
+## Output Contract
+
+Return a strict decision header on first line:
+- `UX_DECISION: PASS`
+- `UX_DECISION: CHANGES`
+
+If CHANGES, include a short ordered remediation list and blocking severity.

--- a/.github/agents/blecs-workflow-authority.agent.md
+++ b/.github/agents/blecs-workflow-authority.agent.md
@@ -1,0 +1,29 @@
+---
+description: "blecs workflow authority: keeps project workflow truth and provides normalized context packets for other agents."
+---
+
+You are the **blecs Workflow Authority Agent**.
+
+Your role is to maintain and provide the workflow source of truth for this repository and downstream agent runs.
+
+## Responsibilities
+
+1. Read workflow and governance sources:
+   - `docs/WORK-ISSUE-WORKFLOW.md`
+   - `.github/copilot-instructions.md`
+   - `.github/workflows/ci.yml`
+2. Produce compact workflow context packets for:
+   - implementation agents,
+   - review/merge agents,
+   - the blecx UX Authority Agent.
+3. Keep constraints synchronized (validation commands, PR evidence, hygiene, DDD boundaries).
+
+## Output Contract
+
+Return:
+- `WORKFLOW_PACKET:` summary
+- `MUST_RULES:` non-negotiable process constraints
+- `UX_INPUTS:` workflow signals relevant for UX decisions
+- `VALIDATION:` exact commands and evidence expectations
+
+Do not design UX directly; route design decisions to `blecs-ux-authority`.

--- a/.github/agents/blecs/README.md
+++ b/.github/agents/blecs/README.md
@@ -1,0 +1,7 @@
+# blecs Command Extensions
+
+This directory contains blecs namespace command prompts (`blecs.*`) that extend the core Spec Kit-compatible flow.
+
+Current extensions focus on:
+- UX authority planning/review
+- Workflow context packet generation

--- a/.github/agents/blecs/blecs.continue-phase-2.md
+++ b/.github/agents/blecs/blecs.continue-phase-2.md
@@ -1,0 +1,16 @@
+---
+description: blecs extension - execute the repeatable phase-2 issue to PR to merge loop.
+---
+
+# blecs.continue-phase-2
+
+Run `/continue-phase-2` process for iterative integration work.
+
+Rules:
+
+- Keep small CI-safe slices.
+- Require review before merge.
+- Require UX authority consultation for UI-affecting scope.
+
+User request:
+$ARGUMENTS

--- a/.github/agents/blecs/blecs.ux.plan.md
+++ b/.github/agents/blecs/blecs.ux.plan.md
@@ -1,0 +1,14 @@
+---
+description: blecs extension - produce UX/navigation plan for a feature.
+---
+
+Generate a UX navigation plan first using `blecs-ux-authority` rules.
+
+Required output:
+- IA/sitemap
+- primary/secondary navigation model
+- responsive baseline
+- grouped artifact interaction map
+
+User request:
+$ARGUMENTS

--- a/.github/agents/blecs/blecs.ux.review.md
+++ b/.github/agents/blecs/blecs.ux.review.md
@@ -1,0 +1,14 @@
+---
+description: blecs extension - run UX authority compliance review for UI-affecting changes.
+---
+
+Review proposed or implemented UI changes and return strict decision output.
+
+First line must be:
+- `UX_DECISION: PASS` or
+- `UX_DECISION: CHANGES`
+
+Include required remediations when CHANGES.
+
+User request:
+$ARGUMENTS

--- a/.github/agents/blecs/blecs.workflow.sync.md
+++ b/.github/agents/blecs/blecs.workflow.sync.md
@@ -1,0 +1,15 @@
+---
+description: blecs extension - build workflow context packet for downstream agents.
+---
+
+Read workflow and repo governance documents and output a compact packet:
+
+- `WORKFLOW_PACKET:`
+- `MUST_RULES:`
+- `UX_INPUTS:`
+- `VALIDATION:`
+
+This packet is consumed by implementation/review agents and `blecs-ux-authority`.
+
+User request:
+$ARGUMENTS

--- a/.github/agents/close-issue.agent.md
+++ b/.github/agents/close-issue.agent.md
@@ -30,6 +30,7 @@ Your job is to package an already-decided outcome (completed / not planned / dup
 - Never close issues by guessing; verify issue/PR/commit state with GitHub CLI.
 - Never commit `projectDocs/` or `configs/llm.json`.
 - If the issue is security-sensitive or ambiguous, stop and ask for maintainer confirmation.
+- For UI/UX-affecting issues, ensure closure evidence references completed `blecs-ux-authority` consultation outcomes.
 - **CRITICAL: NEVER use `/tmp` for temporary files** - ALWAYS use `.tmp/` in workspace root for security.
   - `/tmp` is world-readable and insecure
   - Use `.tmp/close-<issue>.json`, `.tmp/issue-<number>-data.json`, etc.

--- a/.github/agents/pr-merge.agent.md
+++ b/.github/agents/pr-merge.agent.md
@@ -45,6 +45,7 @@ You are done only when all are true:
 - Never commit or stage `projectDocs/` or `configs/llm.json` (backend hygiene). Never commit any secrets (either repo).
 - Do not “fix” unrelated issues. Keep scope to the PR merge + close workflow.
 - If branch protection blocks merging and requires human action (approval/admin), stop and ask for approval or instructions.
+- For UI/UX-affecting PRs, require evidence that `blecs-ux-authority` was consulted and that required UX changes were resolved before merge.
 - **CRITICAL: NEVER use `/tmp` for temporary files** - ALWAYS use `.tmp/` in workspace root for security.
   - `/tmp` is world-readable and insecure
   - Use `.tmp/pr-<number>-metrics.json`, `.tmp/close-<issue>.json`, etc.

--- a/.github/agents/resolve-issue-dev.agent.md
+++ b/.github/agents/resolve-issue-dev.agent.md
@@ -88,6 +88,12 @@ Your **first** assistant message in a run must be short and action-oriented:
 - Don’t commit or modify `projectDocs/` (separate repo).
 - Don’t commit `configs/llm.json`.
 - Don’t do unrelated refactors outside the chosen issue scope.
+
+## UX Design Authority Delegation (mandatory)
+
+- For any work that affects graphical design, navigation, responsive behavior, or UX flow, you must consult `blecs-ux-authority` before finalizing implementation.
+- Treat UX decisions as blocked until the authority returns `UX_DECISION: PASS`.
+- If `UX_DECISION: CHANGES`, apply required changes and re-consult before review/PR completion.
 ## Temporary file storage (MANDATORY)
 
 **CRITICAL: NEVER use `/tmp` for ANY temporary files, scripts, or data.**

--- a/.github/agents/speckit/README.md
+++ b/.github/agents/speckit/README.md
@@ -1,0 +1,5 @@
+# Spec Kit-Compatible Commands
+
+This directory contains Spec Kit-style command prompts (`speckit.*`) for Spec-Driven Development workflows.
+
+These files are intentionally separated from custom agent definitions (`*.agent.md`) in the parent directory to avoid format/discovery conflicts.

--- a/.github/agents/speckit/speckit.constitution.md
+++ b/.github/agents/speckit/speckit.constitution.md
@@ -1,0 +1,13 @@
+---
+description: Create or update project constitution and governing principles.
+---
+
+Create/update the project constitution in `.specify/memory/constitution.md`.
+
+Requirements:
+- Keep principles testable and actionable.
+- Include UX governance rule: graphical design/navigation decisions must be reviewed by `blecs-ux-authority`.
+- Include workflow governance rule: process constraints are sourced from `blecs-workflow-authority`.
+
+User request:
+$ARGUMENTS

--- a/.github/agents/speckit/speckit.implement.md
+++ b/.github/agents/speckit/speckit.implement.md
@@ -1,0 +1,13 @@
+---
+description: Execute tasks according to spec and plan.
+---
+
+Implement tasks from `specs/<feature>/tasks.md`.
+
+Requirements:
+- Respect project DDD and validation constraints.
+- For UI-affecting implementation, request UX decision and block until `UX_DECISION: PASS`.
+- Include final validation evidence.
+
+User request:
+$ARGUMENTS

--- a/.github/agents/speckit/speckit.plan.md
+++ b/.github/agents/speckit/speckit.plan.md
@@ -1,0 +1,13 @@
+---
+description: Create technical implementation plan from spec.
+---
+
+Produce or update `specs/<feature>/plan.md` based on the current spec.
+
+Requirements:
+- Keep architecture and validation explicit.
+- Include UX integration step and consultation checkpoint for UI-affecting scope.
+- Include concrete verification commands.
+
+User request:
+$ARGUMENTS

--- a/.github/agents/speckit/speckit.specify.md
+++ b/.github/agents/speckit/speckit.specify.md
@@ -1,0 +1,13 @@
+---
+description: Define what to build (requirements and user stories).
+---
+
+Produce or update `specs/<feature>/spec.md` from the user request.
+
+Requirements:
+- Focus on what/why, not implementation details.
+- Add explicit UX/navigation acceptance criteria for user-facing features.
+- For UI-affecting scope, require consultation by `blecs-ux-authority`.
+
+User request:
+$ARGUMENTS

--- a/.github/agents/speckit/speckit.tasks.md
+++ b/.github/agents/speckit/speckit.tasks.md
@@ -1,0 +1,13 @@
+---
+description: Generate actionable task list from plan.
+---
+
+Generate or update `specs/<feature>/tasks.md`.
+
+Requirements:
+- Tasks must map to acceptance criteria.
+- For UI tasks, add required UX-authority consultation subtask.
+- Keep tasks small and testable.
+
+User request:
+$ARGUMENTS

--- a/.github/agents/tutorial.agent.md
+++ b/.github/agents/tutorial.agent.md
@@ -27,6 +27,7 @@ Your mission is to produce **best-in-class tutorials** that are:
 - Validate documented steps against real behavior before finalizing.
 - Add a `Feature Gap List` section in Markdown for developer handoff.
 - Add a `Duplicate Content Audit` section in Markdown.
+- For UX/navigation/design guidance embedded in tutorials, consult `blecs-ux-authority` and reflect its PASS/CHANGES outcome.
 
 ## Non-Negotiables
 

--- a/.github/prompts/agents/README.md
+++ b/.github/prompts/agents/README.md
@@ -14,6 +14,7 @@ Do not use these files as generic end-user docs; they are operator rails for age
 
 - `create-issue.md`
 - `Plan.md`
+- `continue-phase-2.md`
 - `resolve-issue-dev.md`
 - `pr-merge.md`
 - `close-issue.md`

--- a/.github/prompts/agents/blecs-ux-authority.md
+++ b/.github/prompts/agents/blecs-ux-authority.md
@@ -1,0 +1,60 @@
+# Agent: blecs-ux-authority
+
+## Objective
+
+Provide authoritative UX/navigation decisions and mandatory PASS/CHANGES review outcomes for UI-affecting work.
+
+## When to Use
+
+- New UI flows, screens, navigation, or layout.
+- Responsive behavior changes.
+- Artifact grouping or interaction model updates.
+- PR review for UI-affecting diffs.
+
+## When Not to Use
+
+- Backend-only changes with no UI/UX impact.
+- Pure infrastructure updates unrelated to user interaction.
+
+## Inputs
+
+- Issue goal and acceptance criteria.
+- Relevant code and diffs.
+- Workflow packet (from blecx workflow authority when available).
+
+## Workflow
+
+1. Read context from `.github/prompts/modules/ux/context-sources.md`.
+2. Create navigation plan first (`ia-navigation`).
+3. Apply responsive + artifact-grouping + a11y modules.
+4. Produce PASS/CHANGES with explicit remediation.
+
+## Output Format
+
+First line must be exactly one of:
+
+- `UX_DECISION: PASS`
+- `UX_DECISION: CHANGES`
+
+Then include:
+
+- `Navigation Plan:`
+- `Responsive Rules:`
+- `Grouping Decisions:`
+- `A11y Baseline:`
+- `Required Changes:` (only if CHANGES)
+
+## Completion Criteria
+
+- Navigation plan exists and is coherent.
+- Responsive/mobile constraints are explicit.
+- Grouping avoids one-tile-per-object anti-pattern where interactions require grouped workflows.
+- Decision is actionable and testable.
+
+## References
+
+- `.github/prompts/modules/ux/ia-navigation.md`
+- `.github/prompts/modules/ux/responsive.md`
+- `.github/prompts/modules/ux/artifact-grouping.md`
+- `.github/prompts/modules/ux/a11y-basics.md`
+- `.github/prompts/modules/ux/pr-checklist.md`

--- a/.github/prompts/agents/blecs-workflow-authority.md
+++ b/.github/prompts/agents/blecs-workflow-authority.md
@@ -1,0 +1,47 @@
+# Agent: blecs-workflow-authority
+
+## Objective
+
+Provide normalized workflow constraints and process context packets for implementation, review, and UX agents.
+
+## When to Use
+
+- Before planning/implementation for issue work.
+- Before UX authority review when workflow constraints matter.
+- Before PR creation/merge checks.
+
+## When Not to Use
+
+- Single-file isolated changes with no process impact.
+- Pure brainstorming without execution intent.
+
+## Inputs
+
+- Issue/PR context and changed-file scope.
+- Workflow docs, CI gate rules, repo instructions.
+
+## Workflow
+
+1. Read `docs/WORK-ISSUE-WORKFLOW.md` and `.github/copilot-instructions.md`.
+2. Read `.github/workflows/ci.yml` for PR evidence constraints.
+3. Produce a compact packet of mandatory rules and validation commands.
+4. Provide UX-specific workflow context for `blecs-ux-authority`.
+
+## Output Format
+
+- `WORKFLOW_PACKET:`
+- `MUST_RULES:`
+- `UX_INPUTS:`
+- `VALIDATION:`
+
+## Completion Criteria
+
+- Workflow packet is actionable and concise.
+- Constraints match current CI/repo rules.
+- UX inputs are explicit for downstream design decisions.
+
+## References
+
+- `docs/WORK-ISSUE-WORKFLOW.md`
+- `.github/workflows/ci.yml`
+- `.github/prompts/modules/ux/delegation-policy.md`

--- a/.github/prompts/agents/close-issue.md
+++ b/.github/prompts/agents/close-issue.md
@@ -24,6 +24,8 @@
    gh issue close <issue-number> --comment "<resolution-comment>"
    ```
 
+   - For UI/UX-affecting issues, ensure closure comment references completed `blecs-ux-authority` consultation outcome.
+
 4. **Verify closure**
    ```bash
    gh issue view <issue-number> --json state | grep -q "CLOSED" && echo "✓ Issue closed" || echo "✗ Failed"
@@ -35,3 +37,4 @@
 - Single state check (no polling)
 - Early exit for already-closed issues
 - No redundant validations
+- Use `.github/prompts/modules/ux/delegation-policy.md` for UX ownership rules

--- a/.github/prompts/agents/continue-phase-2.md
+++ b/.github/prompts/agents/continue-phase-2.md
@@ -1,0 +1,45 @@
+# Agent: continue-phase-2
+
+**Command Name:** `/continue-phase-2`
+
+**Purpose:** Run the phase-2 integration loop with CI-friendly slices and mandatory review-before-merge gates.
+
+**Inputs:**
+
+- Optional issue number (if omitted, select next via `./next-issue`)
+- Optional scope constraints
+
+**Workflow:**
+
+1. Select next issue and validate dependencies.
+2. Create a small implementation slice (target reviewable diff and CI-safe scope).
+3. Run implementation via `scripts/work-issue.py` with existing guardrails.
+4. Ensure UX authority consultation evidence for UI-affecting changes.
+5. Run validations and fix failures.
+6. Run PR review using repository rubric and confirm approval status.
+7. Merge via `scripts/prmerge` only after review + CI pass.
+8. Record outcome and continue with next issue until stop condition.
+
+Primary command:
+
+- `./continue-phase-2`
+- `./continue-phase-2 --max-issues 3`
+- `./continue-phase-2 --issue <n>`
+
+Default cap policy:
+
+- Default run limit is `25` issues.
+- If `--max-issues` is set above `25`, the script asks for explicit override confirmation.
+
+**Hard Rules:**
+
+- Keep one issue per PR.
+- Do not merge without review confirmation.
+- Preserve DDD boundaries and UX delegation policy.
+- Keep process deterministic and repeatable.
+
+**References:**
+
+- `.github/prompts/modules/continue-phase-2-workflow.md`
+- `.github/prompts/modules/resolve-issue-workflow.md`
+- `.github/prompts/pr-review-rubric.md`

--- a/.github/prompts/agents/pr-merge.md
+++ b/.github/prompts/agents/pr-merge.md
@@ -25,6 +25,7 @@ Merge a ready PR safely, close the linked issue with traceability, and clean tem
 - Never fix PR content here; delegate to `resolve-issue-dev`.
 - Prefer `gh pr merge --squash --delete-branch`.
 - Use `.tmp/` (never `/tmp`) for transient files.
+- For UI/UX-affecting PRs, require evidence that `blecs-ux-authority` consultation passed.
 
 ## Workflow
 
@@ -57,4 +58,5 @@ Return:
 ## References
 
 - `.github/prompts/modules/pr-merge-workflow.md`
+- `.github/prompts/modules/ux/delegation-policy.md`
 - `.github/prompts/modules/prompt-quality-baseline.md`

--- a/.github/prompts/agents/resolve-issue-dev.md
+++ b/.github/prompts/agents/resolve-issue-dev.md
@@ -25,6 +25,7 @@ Implement one issue into a small, reviewable PR with DDD-compliant changes and l
 - Priority order: backend first, then client; lowest issue number first.
 - Follow DDD boundaries and keep diffs focused.
 - Use `.tmp/` for PR body and temporary artifacts.
+- If scope affects UI/UX/navigation/responsive behavior, consult `blecs-ux-authority` and block completion until `UX_DECISION: PASS`.
 
 ## Workflow
 
@@ -57,5 +58,6 @@ Return:
 ## References
 
 - `.github/prompts/modules/resolve-issue-workflow.md`
+- `.github/prompts/modules/ux/delegation-policy.md`
 - `.github/prompts/pr-review-rubric.md`
 - `.github/prompts/modules/prompt-quality-baseline.md`

--- a/.github/prompts/agents/tutorial.md
+++ b/.github/prompts/agents/tutorial.md
@@ -26,6 +26,7 @@ Produce accurate, maintainable Markdown tutorials and documentation review findi
 - Final narrative output must be Markdown.
 - Keep UX and TUI paths independent.
 - Findings must include evidence and severity.
+- Any UX/navigation/design recommendation must align with `blecs-ux-authority` decisions.
 
 ## Workflow
 
@@ -56,4 +57,5 @@ Return:
 ## References
 
 - `.github/prompts/modules/tutorial-review-workflow.md`
+- `.github/prompts/modules/ux/delegation-policy.md`
 - `.github/prompts/modules/prompt-quality-baseline.md`

--- a/.github/prompts/modules/continue-phase-2-workflow.md
+++ b/.github/prompts/modules/continue-phase-2-workflow.md
@@ -1,0 +1,36 @@
+# Continue Phase-2 Workflow
+
+Use this module when running `/continue-phase-2`.
+
+Entry command:
+
+- `./continue-phase-2`
+
+Limit policy:
+
+- Default `max-issues` per run is `25`.
+- Values above `25` require explicit runtime confirmation.
+
+## Loop
+
+1. **Issue selection:** run `./next-issue` and capture selected issue.
+2. **Slice sizing:** keep scope to a small CI-safe slice (single issue, minimal touched domains).
+3. **Implement:** run `./scripts/work-issue.py --issue <n>` (or `--plan-only` when needed).
+4. **Validate:** run required checks for changed areas before PR merge.
+5. **Review gate:** ensure PR reviewed and approved before merge.
+6. **Merge gate:** merge with `./scripts/prmerge <issue>` after CI pass.
+7. **Record:** append notes/artifacts and continue to next issue.
+
+## Quality Gates
+
+- Mandatory UX authority consultation for UI-affecting scope.
+- Mandatory PR review before merge.
+- CI must pass for merge path.
+- PR merge slice limits enforced by `scripts/prmerge` policy defaults.
+- No architecture regressions outside issue scope.
+
+## Stop Conditions
+
+- No selectable issues available.
+- Blocking dependency unresolved.
+- Repeated CI failure requiring human decision.

--- a/.github/prompts/modules/resolve-issue-workflow.md
+++ b/.github/prompts/modules/resolve-issue-workflow.md
@@ -4,11 +4,12 @@
 
 1. Select issue (backend-first, lowest number) and confirm scope.
 2. Write compact plan: goal, scope, AC, files, validation commands.
-3. Implement minimal code changes in a dedicated branch.
-4. Run required validations for touched areas.
-5. Commit with `Fixes #<issue>` and push.
-6. Create PR using required template sections.
-7. Address CI failures by root cause and re-validate.
+3. If scope affects UI/UX/navigation/responsive behavior, run `blecs-ux-authority` consultation and capture decision.
+4. Implement minimal code changes in a dedicated branch.
+5. Run required validations for touched areas.
+6. Commit with `Fixes #<issue>` and push.
+7. Create PR using required template sections.
+8. Address CI failures by root cause and re-validate.
 
 ## Validation Baseline
 
@@ -21,3 +22,4 @@
 - Avoid unrelated refactors.
 - Keep diffs reviewable and DDD-compliant.
 - Use `.tmp/` for transient artifacts.
+- Block completion until UX consultation is `PASS` for UI-affecting scope.

--- a/.github/prompts/modules/ux/a11y-basics.md
+++ b/.github/prompts/modules/ux/a11y-basics.md
@@ -1,0 +1,6 @@
+# UX Skill: A11y Baseline
+
+- Require keyboard reachability for primary actions.
+- Preserve logical focus order and visible focus indication.
+- Require semantic labels for form controls and interactive elements.
+- Ensure touch/click targets are comfortably usable on mobile.

--- a/.github/prompts/modules/ux/artifact-grouping.md
+++ b/.github/prompts/modules/ux/artifact-grouping.md
@@ -1,0 +1,6 @@
+# UX Skill: Artifact Grouping
+
+- Identify objects that are consumed or edited together.
+- Group by task flow, not by raw object type count.
+- Prefer progressive disclosure over one-card-per-object dashboards.
+- Preserve clear parent-child and dependency relationships in layout.

--- a/.github/prompts/modules/ux/consult-request.md
+++ b/.github/prompts/modules/ux/consult-request.md
@@ -1,0 +1,14 @@
+# UX Skill: Consult Request Template
+
+Use this payload for UX consultations:
+
+- Issue/PR context
+- User workflow goal
+- Changed files
+- Current behavior
+- Proposed behavior
+- Constraints (tech/process)
+
+Expected response:
+- `UX_DECISION: PASS|CHANGES`
+- Required changes (if any)

--- a/.github/prompts/modules/ux/context-sources.md
+++ b/.github/prompts/modules/ux/context-sources.md
@@ -1,0 +1,10 @@
+# UX Skill: Context Sources
+
+Derive product intent from:
+
+- `README.md`
+- `docs/development.md`
+- `docs/WORK-ISSUE-WORKFLOW.md`
+- active UI code under `apps/web/` and `_external/AI-Agent-Framework-Client/client/`
+
+Always summarize inferred intent before proposing navigation/layout changes.

--- a/.github/prompts/modules/ux/delegation-policy.md
+++ b/.github/prompts/modules/ux/delegation-policy.md
@@ -1,0 +1,5 @@
+# UX Skill: Delegation Policy (Mandatory)
+
+- Non-UX agents must not make final navigation/graphical UX decisions independently.
+- If a change affects UI, navigation, responsive behavior, or visual grouping, consult `blecs-ux-authority`.
+- Block implementation/review completion until UX decision is `PASS` or required `CHANGES` are applied.

--- a/.github/prompts/modules/ux/ia-navigation.md
+++ b/.github/prompts/modules/ux/ia-navigation.md
@@ -1,0 +1,6 @@
+# UX Skill: IA & Navigation
+
+- Always define navigation before component-level layout.
+- Output IA with: primary nav, secondary nav, route grouping, and cross-object flows.
+- Group interacting artifacts into workflow-oriented sections; avoid flat tile spam.
+- Include a desktop and mobile navigation model.

--- a/.github/prompts/modules/ux/pr-checklist.md
+++ b/.github/prompts/modules/ux/pr-checklist.md
@@ -1,0 +1,6 @@
+# UX Skill: PR Checklist
+
+- Include navigation-plan evidence for UI-affecting changes.
+- Include responsive/mobile verification notes.
+- Include UX authority consultation result (`PASS` or remediated `CHANGES`).
+- Include any remaining UX risks and follow-up items.

--- a/.github/prompts/modules/ux/responsive.md
+++ b/.github/prompts/modules/ux/responsive.md
@@ -1,0 +1,7 @@
+# UX Skill: Responsive Rules
+
+- Use mobile-first layout logic.
+- Prevent horizontal cut-off and clipped controls at all breakpoints.
+- Use full available width for primary content while preserving readable density.
+- Ensure interaction targets are mobile-usable and keyboard-accessible.
+- Document breakpoint assumptions when proposing layout changes.

--- a/.github/prompts/pr-review-rubric.md
+++ b/.github/prompts/pr-review-rubric.md
@@ -23,9 +23,13 @@ Use this rubric for both human and agent-based PR reviews.
    - potential bugs, error handling, status codes
 5. Tests
    - tests updated/added? gaps?
-6. Breaking Changes / Client Impact
+6. UX / Navigation Compliance (for UI-affecting diffs)
+   - `blecs-ux-authority` consulted: pass/fail + evidence
+   - responsive/mobile checks included: pass/fail + evidence
+   - navigation/grouping quality: pass/fail + notes
+7. Breaking Changes / Client Impact
    - requires client repo change? yes/no + details
-7. Recommendation
+8. Recommendation
    - APPROVE / REQUEST CHANGES
    - required changes (max 5), ordered by severity
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Validate planning issue specs
         run: ./scripts/validate_issue_specs.sh
 
+      - name: Validate continue-phase-2 policy
+        run: python ./scripts/check_continue_phase2_policy.py
+
   backend-ci:
     runs-on: ubuntu-latest
 
@@ -107,6 +110,16 @@ jobs:
             const changed = files.map(f => f.filename);
             const backendTouched = changed.some(p => p.startsWith('apps/api/'));
             const testsTouched = changed.some(p => p.startsWith('tests/'));
+            const uiTouched = changed.some(p =>
+              p.startsWith('apps/web/') ||
+              p.startsWith('client/src/') ||
+              p.startsWith('_external/AI-Agent-Framework-Client/client/') ||
+              /\.(css|scss|sass|tsx|jsx)$/i.test(p)
+            );
+
+            const uxSectionHeading = '## UX / Navigation Review';
+            const uxSection = sectionText(body, uxSectionHeading);
+            const uxBoxes = checkboxes(uxSection);
 
             // Require test execution evidence for backend changes.
             // We do NOT require modifying tests on every change (format-only, refactors, etc.),
@@ -116,6 +129,21 @@ jobs:
               problems.push(
                 'Backend code changed under apps/api/ but no tests were changed; you must run tests and check the pytest item in Validation Evidence.'
               );
+            }
+
+            if (uiTouched) {
+              if (!body.includes(uxSectionHeading)) {
+                problems.push('UI/UX-affecting files changed; PR description must include a "## UX / Navigation Review" section.');
+              } else if (uxBoxes.length === 0) {
+                problems.push('UX / Navigation Review section must include checkbox evidence.');
+              } else if (!allChecked(uxBoxes)) {
+                problems.push('All UX / Navigation Review checkboxes must be checked for UI/UX-affecting changes.');
+              }
+
+              const uxConsultChecked = uxBoxes.some(l => /^- \[[xX]\].*blecs-ux-authority.*(consulted|pass)/i.test(l));
+              if (!uxConsultChecked) {
+                problems.push('UX / Navigation Review must include a checked blecs-ux-authority consultation result for UI/UX-affecting changes.');
+              }
             }
 
             if (problems.length) {

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,0 +1,12 @@
+# Project Constitution
+
+## Purpose
+
+Build a robust AI-agent-driven product development system with Spec-Driven Development compatibility.
+
+## Core Governance
+
+1. Spec-first delivery: use spec → plan → tasks → implement flow for feature work.
+2. UX authority rule: all graphical UX/navigation decisions must be reviewed by `blecs-ux-authority`.
+3. Workflow authority rule: workflow constraints are normalized by `blecs-workflow-authority`.
+4. Validation evidence is mandatory for PR acceptance.

--- a/continue-phase-2
+++ b/continue-phase-2
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+exec ./scripts/continue-phase-2.sh "$@"

--- a/planning/issues/.published-map.json
+++ b/planning/issues/.published-map.json
@@ -1,0 +1,71 @@
+{
+  "entries": {
+    "blecx/AI-Agent-Framework-Client|P2-UX-01": {
+      "issue_number": 216,
+      "issue_url": "https://github.com/blecx/AI-Agent-Framework-Client/issues/216",
+      "repo": "blecx/AI-Agent-Framework-Client",
+      "repo_alias": "AI-Agent-Framework-Client",
+      "source_file": "planning/issues/phase-2-blecs-ux-authority.yml",
+      "source_id": "P2-UX-01",
+      "status": "created",
+      "title": "Phase 2 \u2014 Consume blecs UX packet in client issue workflow",
+      "title_hash": "6f7f3e37d6e0"
+    },
+    "blecx/AI-Agent-Framework-Client|P2-UX-02": {
+      "issue_number": 217,
+      "issue_url": "https://github.com/blecx/AI-Agent-Framework-Client/issues/217",
+      "repo": "blecx/AI-Agent-Framework-Client",
+      "repo_alias": "AI-Agent-Framework-Client",
+      "source_file": "planning/issues/phase-2-blecs-ux-authority.yml",
+      "source_id": "P2-UX-02",
+      "status": "created",
+      "title": "Phase 2 \u2014 Add client PR UX evidence gate aligned with blecs authority",
+      "title_hash": "c864d733a443"
+    },
+    "blecx/AI-Agent-Framework|P2-BE-01": {
+      "issue_number": 375,
+      "issue_url": "https://github.com/blecx/AI-Agent-Framework/issues/375",
+      "repo": "blecx/AI-Agent-Framework",
+      "repo_alias": "AI-Agent-Framework",
+      "source_file": "planning/issues/phase-2-blecs-ux-authority.yml",
+      "source_id": "P2-BE-01",
+      "status": "created",
+      "title": "Phase 2 \u2014 Enforce speckit/blecs command contract validation",
+      "title_hash": "a46d5e7f5299"
+    },
+    "blecx/AI-Agent-Framework|P2-BE-02": {
+      "issue_number": 376,
+      "issue_url": "https://github.com/blecx/AI-Agent-Framework/issues/376",
+      "repo": "blecx/AI-Agent-Framework",
+      "repo_alias": "AI-Agent-Framework",
+      "source_file": "planning/issues/phase-2-blecs-ux-authority.yml",
+      "source_id": "P2-BE-02",
+      "status": "created",
+      "title": "Phase 2 \u2014 Wire operational scripts to explicit speckit flow",
+      "title_hash": "975b79746933"
+    },
+    "blecx/AI-Agent-Framework|P2-BE-03": {
+      "issue_number": 377,
+      "issue_url": "https://github.com/blecx/AI-Agent-Framework/issues/377",
+      "repo": "blecx/AI-Agent-Framework",
+      "repo_alias": "AI-Agent-Framework",
+      "source_file": "planning/issues/phase-2-blecs-ux-authority.yml",
+      "source_id": "P2-BE-03",
+      "status": "created",
+      "title": "Phase 2 \u2014 Add anti-bypass tests for mandatory UX authority consultation",
+      "title_hash": "9d8aab8c913f"
+    },
+    "blecx/AI-Agent-Framework|P2-BE-04": {
+      "issue_number": 378,
+      "issue_url": "https://github.com/blecx/AI-Agent-Framework/issues/378",
+      "repo": "blecx/AI-Agent-Framework",
+      "repo_alias": "AI-Agent-Framework",
+      "source_file": "planning/issues/phase-2-blecs-ux-authority.yml",
+      "source_id": "P2-BE-04",
+      "status": "created",
+      "title": "Phase 2 \u2014 Publish migration playbook for blecs UX authority operations",
+      "title_hash": "d8a153ff317e"
+    }
+  },
+  "version": 1
+}

--- a/planning/issues/phase-2-blecs-ux-authority.yml
+++ b/planning/issues/phase-2-blecs-ux-authority.yml
@@ -1,0 +1,244 @@
+AI-Agent-Framework:
+  - id: "P2-BE-01"
+    title: "Phase 2 — Enforce speckit/blecs command contract validation"
+    labels: ["enhancement"]
+    size_estimate: "S"
+    body: |
+      ## Goal / Problem Statement
+      Prevent command-domain drift by validating that `speckit.*` and `blecs.*` prompts keep their contract boundaries and remain non-conflicting.
+
+      ## Scope
+      ### In Scope
+      - Add validator checks for command naming, namespace collisions, and required contract markers.
+      - Integrate validator in existing validation workflow.
+      - Fail fast on invalid command prompt structure.
+      ### Out of Scope
+      - Rewriting existing command implementations.
+      - Expanding agent behavior beyond contract validation.
+      ### Dependencies
+      - None.
+
+      ## Acceptance Criteria
+      - [ ] Validation fails when a `blecs.*` command shadows a `speckit.*` command.
+      - [ ] Validation fails when required contract markers are missing.
+      - [ ] Validation passes for current `speckit.*` and `blecs.*` command files.
+      - [ ] CI includes the validator.
+
+      ## Technical Approach
+      - Extend existing prompt/contract validation scripts.
+      - Add deterministic checks for namespace ownership and required sections.
+      - Keep implementation script-level and non-invasive to runtime logic.
+
+      ## Testing Requirements
+      - `python -m pytest tests/ -k "prompt or contract" -q`
+      - `python -m scripts.check_issue_specs --paths "planning/issues/*.yml" --no-legacy --strict-sections`
+
+      ## Documentation Updates
+      - [ ] Update `docs/skills.md` with command contract validation notes.
+      - [ ] Update `docs/WORK-ISSUE-WORKFLOW.md` with validation placement.
+
+      ## Cross-Repository Coordination
+      No direct client change required.
+
+  - id: "P2-BE-02"
+    title: "Phase 2 — Wire operational scripts to explicit speckit flow"
+    labels: ["enhancement"]
+    size_estimate: "M"
+    body: |
+      ## Goal / Problem Statement
+      Ensure issue execution scripts explicitly invoke the Spec Kit-compatible workflow stages (`specify`, `plan`, `tasks`, `implement`) before coding and review.
+
+      ## Scope
+      ### In Scope
+      - Update operational scripts to call explicit `speckit.*` stages in deterministic order.
+      - Preserve `blecs` extensions as additive overlays.
+      - Record stage outputs in `.tmp/` for traceability.
+      ### Out of Scope
+      - New workflow stages.
+      - Changes to issue selection policy.
+      ### Dependencies
+      - P2-BE-01.
+
+      ## Acceptance Criteria
+      - [ ] `work-issue` flow executes the defined stage sequence for eligible issues.
+      - [ ] Stage failure aborts downstream stages with actionable errors.
+      - [ ] `.tmp/` artifacts capture stage outputs per issue run.
+      - [ ] Existing dry-run behavior remains functional.
+
+      ## Technical Approach
+      - Refactor script orchestration to centralize stage invocation.
+      - Add minimal adapters around current workflow entrypoints.
+      - Keep backward-compatible script flags.
+
+      ## Testing Requirements
+      - `python -m pytest tests/ -k "work_issue or workflow" -q`
+      - `gh issue list --repo blecx/AI-Agent-Framework --limit 1`
+      - `curl http://localhost:8000/health`
+
+      ## Documentation Updates
+      - [ ] Update `docs/WORK-ISSUE-WORKFLOW.md` with explicit stage sequence.
+      - [ ] Update `docs/NEXT-ISSUE-COMMAND.md` if behavior changes are user-visible.
+
+      ## Cross-Repository Coordination
+      No direct client change required.
+
+  - id: "P2-BE-03"
+    title: "Phase 2 — Add anti-bypass tests for mandatory UX authority consultation"
+    labels: ["enhancement"]
+    size_estimate: "M"
+    body: |
+      ## Goal / Problem Statement
+      Prevent regressions where UI-affecting work bypasses mandatory consultation with `blecs-ux-authority`.
+
+      ## Scope
+      ### In Scope
+      - Add positive/negative tests for runtime UX gate behavior.
+      - Add CI-gate tests for PR-body UX evidence enforcement.
+      - Add fixtures covering UI-touching and non-UI changes.
+      ### Out of Scope
+      - Expanding UX decision model content.
+      - Replacing existing CI workflow architecture.
+      ### Dependencies
+      - P2-BE-02.
+
+      ## Acceptance Criteria
+      - [ ] Runtime tests fail when UI work omits required UX consultation evidence.
+      - [ ] Runtime tests pass when evidence is present.
+      - [ ] CI-gate tests cover both pass/fail PR-body paths.
+      - [ ] Tests are deterministic and CI-friendly.
+
+      ## Technical Approach
+      - Add focused tests adjacent to workflow and CI gate scripts.
+      - Reuse current UI-impact detection rules.
+      - Keep fixture set minimal but representative.
+
+      ## Testing Requirements
+      - `./.venv/bin/python -m pytest tests/ -k "ux or workflow or ci" -q`
+      - `./scripts/validate_prompts.sh`
+
+      ## Documentation Updates
+      - [ ] Update `tests/README.md` with UX gate test commands.
+
+      ## Cross-Repository Coordination
+      No direct client change required.
+
+  - id: "P2-BE-04"
+    title: "Phase 2 — Publish migration playbook for blecs UX authority operations"
+    labels: ["documentation"]
+    size_estimate: "S"
+    body: |
+      ## Goal / Problem Statement
+      Provide a concise operational playbook so contributors can execute and verify the `blecs` UX-governed workflow without ambiguity.
+
+      ## Scope
+      ### In Scope
+      - Document required sequence for planning, issue work, review, and merge under `blecs` governance.
+      - Include command references and expected artifacts.
+      - Include failure triage for common policy/gate violations.
+      ### Out of Scope
+      - New automation scripts.
+      - UI feature design itself.
+      ### Dependencies
+      - P2-BE-03.
+
+      ## Acceptance Criteria
+      - [ ] Playbook exists in docs and is discoverable from top-level docs.
+      - [ ] Workflow sequence includes `speckit` + `blecs` interaction points.
+      - [ ] Troubleshooting section covers at least 3 common failure modes.
+      - [ ] Commands in the playbook are validated locally.
+
+      ## Technical Approach
+      - Add one authoritative document and link from existing workflow docs.
+      - Reuse terminology already present in agent and prompt contracts.
+
+      ## Testing Requirements
+      - `python -m pytest tests/ -k "docs or workflow" -q`
+      - `python -m scripts.check_issue_specs --paths "planning/issues/*.yml" --no-legacy --strict-sections`
+
+      ## Documentation Updates
+      - [ ] Add `docs/agents/blecs-phase-2-playbook.md`.
+      - [ ] Update `docs/README.md` with playbook link.
+
+      ## Cross-Repository Coordination
+      Yes - client repo should align consumption workflow documentation after backend playbook lands.
+
+AI-Agent-Framework-Client:
+  - id: "P2-UX-01"
+    title: "Phase 2 — Consume blecs UX packet in client issue workflow"
+    labels: ["enhancement", "webui/ux", "agents", "size:S", "step:2"]
+    size_estimate: "S"
+    body: |
+      ## Goal / Problem Statement
+      Ensure client-side issue workflows consume the UX packet produced by backend governance so UX decisions remain consistent across repositories.
+
+      ## Scope
+      ### In Scope
+      - Add client workflow hook to read and apply UX packet guidance.
+      - Enforce packet presence for UI-affecting tasks.
+      - Keep behavior backward compatible for non-UI tasks.
+      ### Out of Scope
+      - Redesign of client components.
+      - New backend APIs.
+      ### Dependencies
+      - AI-Agent-Framework P2-BE-04.
+
+      ## Acceptance Criteria
+      - [ ] UI-affecting client tasks fail fast without UX packet.
+      - [ ] UI-affecting client tasks proceed with packet present.
+      - [ ] Non-UI client tasks remain unaffected.
+      - [ ] Evidence is visible in PR body for UX review.
+
+      ## Technical Approach
+      - Extend existing client issue workflow script/prompt adapters.
+      - Read packet artifact from agreed path and map it to review checklist entries.
+
+      ## Testing Requirements
+      - `npm run lint`
+      - `npm run build`
+      - client workflow dry-run command with and without packet
+
+      ## Documentation Updates
+      - [ ] Update client workflow docs with packet requirement.
+
+      ## Cross-Repository Coordination
+      Yes - depends on backend playbook and packet contract.
+
+  - id: "P2-UX-02"
+    title: "Phase 2 — Add client PR UX evidence gate aligned with blecs authority"
+    labels: ["enhancement", "ci/cd", "webui/ux", "size:S", "step:2"]
+    size_estimate: "S"
+    body: |
+      ## Goal / Problem Statement
+      Align client CI gates with backend UX governance by requiring explicit UX evidence on UI-affecting PRs.
+
+      ## Scope
+      ### In Scope
+      - Add PR-body validation for mandatory UX evidence fields on UI-impacting changes.
+      - Reuse same evidence structure used by backend gate.
+      - Add clear remediation text in CI output.
+      ### Out of Scope
+      - Non-PR workflows.
+      - Broader CI redesign.
+      ### Dependencies
+      - P2-UX-01.
+
+      ## Acceptance Criteria
+      - [ ] Client CI fails when required UX evidence is missing for UI changes.
+      - [ ] Client CI passes when UX evidence is complete.
+      - [ ] Non-UI PRs are not blocked by UX-specific fields.
+      - [ ] Validation messaging is actionable.
+
+      ## Technical Approach
+      - Add a focused validation script and wire it to existing client CI.
+      - Mirror backend UX evidence schema to reduce drift.
+
+      ## Testing Requirements
+      - `npm run lint`
+      - `npm run build`
+      - CI validation script unit tests (pass/fail fixtures)
+
+      ## Documentation Updates
+      - [ ] Update client contributing docs with UX evidence requirements.
+
+      ## Cross-Repository Coordination
+      Yes - keep evidence schema synchronized with backend gate implementation.

--- a/scripts/check_continue_phase2_policy.py
+++ b/scripts/check_continue_phase2_policy.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Validate /continue-phase-2 cap policy mechanics.
+
+Enforces:
+- default max issues is 25
+- cap is 25
+- values above cap require explicit override confirmation
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LOOP_SCRIPT = ROOT / "scripts" / "continue-phase-2.sh"
+PROMPT_FILE = ROOT / ".github" / "prompts" / "agents" / "continue-phase-2.md"
+MODULE_FILE = ROOT / ".github" / "prompts" / "modules" / "continue-phase-2-workflow.md"
+
+
+def _must_contain(path: Path, snippet: str, errors: list[str]) -> None:
+    text = path.read_text(encoding="utf-8")
+    if snippet not in text:
+        errors.append(f"{path}: missing required snippet: {snippet}")
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    if not LOOP_SCRIPT.exists():
+        errors.append(f"Missing loop script: {LOOP_SCRIPT}")
+    else:
+        _must_contain(LOOP_SCRIPT, "MAX_ISSUES=25", errors)
+        _must_contain(LOOP_SCRIPT, "MAX_ISSUES_CAP=25", errors)
+        _must_contain(LOOP_SCRIPT, 'if [[ "$MAX_ISSUES" -gt "$MAX_ISSUES_CAP" ]]', errors)
+        _must_contain(LOOP_SCRIPT, "Override cap and continue? (y/N):", errors)
+
+    if PROMPT_FILE.exists():
+        _must_contain(PROMPT_FILE, "Default run limit is `25` issues", errors)
+
+    if MODULE_FILE.exists():
+        _must_contain(MODULE_FILE, "Default `max-issues` per run is `25`", errors)
+
+    if errors:
+        print("❌ continue-phase-2 policy check failed")
+        for err in errors:
+            print(f"- {err}")
+        return 1
+
+    print("✅ continue-phase-2 policy check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/continue-phase-2.sh
+++ b/scripts/continue-phase-2.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MAX_ISSUES=25
+ISSUE_OVERRIDE=""
+DRY_RUN=0
+NO_RECONCILE=0
+MAX_ISSUES_CAP=25
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/continue-phase-2.sh [options]
+
+Runs the /continue-phase-2 loop:
+  next-issue -> work-issue -> prmerge
+
+Options:
+  --issue <n>           Run a single explicit issue.
+  --max-issues <n>      Stop after n issues (default: 25).
+  --dry-run             Select and print actions, do not execute work/merge.
+  --no-reconcile        Pass --skip-reconcile to next-issue.
+  -h, --help            Show this help.
+
+Environment:
+  PRMERGE_MAX_FILES, PRMERGE_MAX_LINES, PRMERGE_ALLOW_LARGE_SLICE,
+  PRMERGE_ALLOW_UNAPPROVED
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --issue)
+      ISSUE_OVERRIDE="${2:-}"
+      shift 2
+      ;;
+    --max-issues)
+      MAX_ISSUES="${2:-0}"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --no-reconcile)
+      NO_RECONCILE=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "$MAX_ISSUES" =~ ^[0-9]+$ ]]; then
+  echo "Invalid --max-issues value: $MAX_ISSUES" >&2
+  exit 1
+fi
+
+if [[ "$MAX_ISSUES" -gt "$MAX_ISSUES_CAP" ]]; then
+  echo "Requested --max-issues=$MAX_ISSUES exceeds default cap ($MAX_ISSUES_CAP)."
+  read -r -p "Override cap and continue? (y/N): " override_cap
+  if [[ ! "$override_cap" =~ ^[Yy]$ ]]; then
+    echo "Cancelled. Re-run with --max-issues <= $MAX_ISSUES_CAP or confirm override."
+    exit 1
+  fi
+fi
+
+extract_issue_number() {
+  local text="$1"
+  local n
+  n=$(echo "$text" | grep -oE 'Issue #[0-9]+' | head -1 | grep -oE '[0-9]+' || true)
+  echo "$n"
+}
+
+count=0
+
+while true; do
+  if [[ -n "$ISSUE_OVERRIDE" ]]; then
+    issue="$ISSUE_OVERRIDE"
+    ISSUE_OVERRIDE=""
+  else
+    next_issue_cmd=("./next-issue")
+    if [[ "$NO_RECONCILE" == "1" ]]; then
+      next_issue_cmd+=("--skip-reconcile")
+    fi
+
+    set +e
+    selection_output="$(${next_issue_cmd[@]} 2>&1)"
+    selection_rc=$?
+    set -e
+
+    if [[ $selection_rc -ne 0 ]]; then
+      echo "$selection_output"
+      echo "No selectable issues or selection failed; stopping phase-2 loop."
+      break
+    fi
+
+    issue=$(extract_issue_number "$selection_output")
+    if [[ -z "$issue" ]]; then
+      echo "$selection_output"
+      echo "Could not parse issue number from next-issue output; stopping." >&2
+      exit 2
+    fi
+  fi
+
+  echo "============================================================"
+  echo "/continue-phase-2 :: Processing Issue #$issue"
+  echo "============================================================"
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "[dry-run] Would run: ./scripts/work-issue.py --issue $issue"
+    echo "[dry-run] Would run: ./scripts/prmerge $issue"
+  else
+    ./scripts/work-issue.py --issue "$issue"
+    ./scripts/prmerge "$issue"
+  fi
+
+  count=$((count + 1))
+  if [[ "$count" -ge "$MAX_ISSUES" ]]; then
+    echo "Reached --max-issues=$MAX_ISSUES; stopping."
+    break
+  fi
+
+done
+
+echo "Phase-2 loop finished. Processed issues: $count"

--- a/scripts/prmerge
+++ b/scripts/prmerge
@@ -30,6 +30,12 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
+# Merge policy defaults (override via environment if needed)
+PRMERGE_MAX_FILES=${PRMERGE_MAX_FILES:-12}
+PRMERGE_MAX_LINES=${PRMERGE_MAX_LINES:-500}
+PRMERGE_ALLOW_LARGE_SLICE=${PRMERGE_ALLOW_LARGE_SLICE:-0}
+PRMERGE_ALLOW_UNAPPROVED=${PRMERGE_ALLOW_UNAPPROVED:-0}
+
 # Helper functions (must be defined before first use)
 info() {
     echo -e "${BLUE}ℹ${NC} $1"
@@ -590,13 +596,14 @@ success "Found PR #$PR_NUMBER"
 
 # Get PR details
 info "Checking PR status..."
-PR_JSON=$(gh pr view "$PR_NUMBER" --json number,title,state,mergeable,mergeStateStatus,statusCheckRollup,headRefName,url)
+PR_JSON=$(gh pr view "$PR_NUMBER" --json number,title,state,mergeable,mergeStateStatus,statusCheckRollup,headRefName,url,reviewDecision)
 PR_STATE=$(echo "$PR_JSON" | jq -r '.state')
 PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
 PR_MERGEABLE=$(echo "$PR_JSON" | jq -r '.mergeable')
 PR_MERGE_STATE=$(echo "$PR_JSON" | jq -r '.mergeStateStatus')
 PR_BRANCH=$(echo "$PR_JSON" | jq -r '.headRefName')
 PR_URL=$(echo "$PR_JSON" | jq -r '.url')
+PR_REVIEW_DECISION=$(echo "$PR_JSON" | jq -r '.reviewDecision // ""')
 
 echo ""
 echo "PR Details:"
@@ -605,6 +612,7 @@ echo "  Title: $PR_TITLE"
 echo "  State: $PR_STATE"
 echo "  Branch: $PR_BRANCH"
 echo "  URL: $PR_URL"
+echo "  Review decision: ${PR_REVIEW_DECISION:-NONE}"
 echo ""
 
 # Check if already merged
@@ -672,6 +680,37 @@ else
         error "PR template validation failed. Please fix the PR description."
         warning "PR URL: $PR_URL"
         exit 1
+    fi
+
+    # Enforce small-slice policy for CI-friendly merges
+    PR_FILES_POLICY=$(gh pr view "$PR_NUMBER" --json files --jq '.files | length')
+    PR_ADDITIONS_POLICY=$(gh pr view "$PR_NUMBER" --json additions --jq '.additions')
+    PR_DELETIONS_POLICY=$(gh pr view "$PR_NUMBER" --json deletions --jq '.deletions')
+    PR_TOTAL_LINES_POLICY=$((PR_ADDITIONS_POLICY + PR_DELETIONS_POLICY))
+
+    if [ "$PRMERGE_ALLOW_LARGE_SLICE" != "1" ]; then
+        if [ "$PR_FILES_POLICY" -gt "$PRMERGE_MAX_FILES" ] || [ "$PR_TOTAL_LINES_POLICY" -gt "$PRMERGE_MAX_LINES" ]; then
+            error "PR exceeds small-slice merge policy"
+            echo ""
+            echo "Policy limits: files <= $PRMERGE_MAX_FILES, total changed lines <= $PRMERGE_MAX_LINES"
+            echo "PR metrics: files=$PR_FILES_POLICY, additions=$PR_ADDITIONS_POLICY, deletions=$PR_DELETIONS_POLICY, total=$PR_TOTAL_LINES_POLICY"
+            echo ""
+            echo "Split into smaller slices before merge, or explicitly override for exceptional cases:"
+            echo "  PRMERGE_ALLOW_LARGE_SLICE=1 ./scripts/prmerge $ISSUE_NUMBER"
+            exit 1
+        fi
+    fi
+
+    # Enforce mandatory review approval gate
+    if [ "$PRMERGE_ALLOW_UNAPPROVED" != "1" ]; then
+        if [ "$PR_REVIEW_DECISION" != "APPROVED" ]; then
+            error "PR review gate failed: reviewDecision is '${PR_REVIEW_DECISION:-NONE}' (requires APPROVED)"
+            echo ""
+            echo "Please complete review approval in GitHub before merge: $PR_URL"
+            echo "For exceptional override only:"
+            echo "  PRMERGE_ALLOW_UNAPPROVED=1 ./scripts/prmerge $ISSUE_NUMBER"
+            exit 1
+        fi
     fi
     
     section "Step 2: Review PR"

--- a/specs/001-blecs-agent-migration/plan.md
+++ b/specs/001-blecs-agent-migration/plan.md
@@ -1,0 +1,108 @@
+# Plan: blecs Agent Migration
+
+## Decision Answer
+
+Current state is not fully compliant with your latest requirement because the implemented namespace is blecx, not blecs.
+
+This rewritten plan enforces:
+
+- own namespace: blecs
+- Spec Kit-compatible behavior
+- no interference with upstream Spec Kit
+
+1. Introduce blecs UX/workflow authority agents.
+2. Add reusable UX modules and delegation policy.
+3. Wire autonomous workflow UX consultation gate.
+4. Enforce PR UX evidence in CI for UI-affecting changes.
+5. Migrate remaining agent prompts to consume workflow packets and UX delegation policy.
+
+## Namespace and Compatibility Model
+
+1. Keep core Spec Kit-compatible commands under a dedicated speckit command domain.
+2. Introduce blecs command domain as additive extensions only.
+3. Do not override, rename, or alter core Spec Kit-compatible command semantics.
+4. Keep custom agent definitions separate from command prompt directories to prevent collisions.
+
+## Non-Interference Rules
+
+- blecs extensions must not shadow speckit command names.
+- blecs commands may consume workflow packets and UX gates but must not mutate core Spec Kit flow contracts.
+- CI checks validate coexistence, not replacement, of Spec Kit-compatible behavior.
+
+## Phase 1 Completion Status
+
+Status: Phase 1 completed and namespace alignment completed (blecs)
+
+Delivered:
+
+- UX authority and workflow authority custom agents
+- reusable UX modules and mandatory delegation policy
+- Spec Kit-compatible command prompt domains (`speckit.*` and `blecs.*`)
+- runtime UX gate in autonomous workflow execution
+- CI UX review gate for UI-affecting changes
+- delegation wiring in existing agent contracts and rails
+
+Namespace alignment completed:
+
+- renamed namespace assets to blecs
+- updated delegation references to `blecs-ux-authority`
+- updated command extension names to `blecs.*`
+
+## Optimization Recommendations
+
+1. Add a shared UI-impact detector utility so runtime and CI use identical scope logic.
+2. Add a validator for `.github/agents/speckit/*.md` and `.github/agents/blecs/*.md` frontmatter/contract checks.
+3. Add a compact workflow-packet cache to reduce repeated long-context reads.
+4. Add automated tests for CI gate logic (positive and negative PR-body examples).
+5. Add model-role option for dedicated `ux` role in `agents/llm_client.py` when needed.
+
+## Phase 2 Plan: Integration and Transition
+
+1. Integrate `speckit.*` and `blecs.*` commands into operational scripts (`scripts/work-issue.py` and related workflows).
+2. Route all issue planning to workflow packets from `blecs-workflow-authority`.
+3. Require and persist UX consultation artifacts for UI issues in `.tmp/` and PR body evidence.
+4. Migrate remaining agent prompts/workflows to consume Spec Kit artifacts (`.specify/` + `specs/`).
+5. Add documentation for day-to-day usage and migration order across backend/client repos.
+6. Add regression checks to ensure no agent bypasses UX authority for graphical design scope.
+
+## Phase 2 Started
+
+Started work completed:
+
+- execution flow now builds a workflow packet (blecs workflow authority contract) before planning
+- execution flow now persists UX consultation artifacts in `.tmp/ux-consult-issue-<issue>.md`
+- UX gate runtime prompt text now uses blecs namespace
+
+## Requirement Coverage Review
+
+1. Own namespace (`blecs`) is implemented.
+2. Spec Kit-compatible core flow remains in `speckit.*` command prompts.
+3. blecs extensions are additive and separate from core speckit commands.
+4. Directory and naming separation avoids collision with custom agent files.
+5. Mandatory UX consultation is enforced in runtime flow, prompts, and CI gate text.
+
+Open items (phase 2 continuation):
+
+- operational script-level invocation of `speckit.*` command flow
+- dedicated validators for command prompt contracts
+- anti-bypass automated tests for UI/UX consultation policy
+
+## Phase 2 Acceptance Criteria
+
+- blecs namespace is the only custom extension namespace.
+- speckit-compatible commands continue to behave as expected.
+- no naming or discovery conflict between custom agents and command prompts.
+- UX authority consultation remains mandatory for UI-affecting work.
+
+## Phase 2 Issue Slicing (Canonical)
+
+Issue slicing is now formalized in `planning/issues/phase-2-blecs-ux-authority.yml` with backend-first dependency order:
+
+1. `P2-BE-01` Contract validator for `speckit.*` + `blecs.*` boundaries (S)
+2. `P2-BE-02` Operational script wiring to explicit Spec Kit stage flow (M)
+3. `P2-BE-03` Anti-bypass runtime/CI tests for mandatory UX consultation (M)
+4. `P2-BE-04` Migration playbook and operational documentation (S)
+5. `P2-UX-01` Client workflow consumption of UX packet contract (S)
+6. `P2-UX-02` Client CI UX evidence gate alignment (S)
+
+This sequencing preserves backend-first dependency constraints and keeps each issue small/reviewable for one-issue-per-PR execution.

--- a/specs/001-blecs-agent-migration/spec.md
+++ b/specs/001-blecs-agent-migration/spec.md
@@ -1,0 +1,21 @@
+# Spec: blecs Agent Migration
+
+## Goal
+
+Transition existing project agent workflows to a blecs namespace while remaining compatible with GitHub Spec Kit structures and behavior.
+
+## Requirements
+
+- Keep existing Copilot custom agents working.
+- Use an own namespace: blecs.
+- Preserve Spec Kit command semantics and workflow order (constitution, specify, plan, tasks, implement).
+- Ensure no interference with upstream Spec Kit command contracts and directories.
+- Add Spec Kit-compatible command prompts under dedicated directories.
+- Make UX authority consultation mandatory for UI-affecting work.
+- Add workflow authority packet support for downstream agents.
+
+## Compatibility Constraints
+
+- Upstream-like command behavior must be maintained for Spec Kit-compatible flow.
+- blecs namespace extensions must be additive and must not override or mutate core Spec Kit command behavior.
+- Command directories and custom agent directories must remain separated to avoid discovery and format conflicts.

--- a/specs/001-blecs-agent-migration/tasks.md
+++ b/specs/001-blecs-agent-migration/tasks.md
@@ -1,0 +1,25 @@
+# Tasks: blecs Agent Migration
+
+- [x] Add blecs authority agent definitions
+- [x] Add UX modular prompt skills
+- [x] Add Spec Kit-compatible command prompts
+- [x] Wire runtime UX gate in autonomous workflow
+- [x] Extend CI PR gate for UX evidence
+- [x] Update existing agents to enforce UX delegation
+- [x] Validate prompt quality and CI behavior
+
+## Namespace Alignment TODO (Required Before Phase 2)
+
+- [x] Rename blecx authority agent files and IDs to blecs equivalents
+- [x] Rename old extension command files to blecs extension files (`blecs.*`)
+- [x] Update all prompt/CI/workflow references to blecs authority names
+- [x] Re-run prompt and syntax validation after namespace migration
+
+## Phase 2 TODOs (Integration)
+
+- [ ] Integrate `speckit.*` command flow into operational scripts
+- [x] Integrate `blecs.*` workflow packet generation into issue execution flow
+- [x] Persist UX consultation outcomes in issue/PR evidence artifacts
+- [ ] Add CI/prompt validators for Spec Kit-compatible command prompt contracts
+- [ ] Add docs for full transition from legacy prompt flow to blecs Spec Kit flow
+- [ ] Add automated checks to prevent UX-authority bypass on UI-affecting issues


### PR DESCRIPTION
## Summary
- add blecs UX/workflow authority agents and delegation rails
- add spec-kit-compatible command domains (`speckit.*`) plus additive `blecs.*` extensions
- enforce UX consultation in runtime workflow and PR review/CI checks
- add `/continue-phase-2` loop command and policy validator
- add canonical phase-2 issue slicing spec and publish mapping

## Validation
- /home/sw/work/AI-Agent-Framework/.venv/bin/python scripts/check_issue_specs.py --paths "planning/issues/phase-2-blecs-ux-authority.yml" --no-legacy --strict-sections
- /home/sw/work/AI-Agent-Framework/.venv/bin/python scripts/check_continue_phase2_policy.py

## Traceability
Closes #375
Closes #376
Closes #377
Closes #378
