### PR TITLE
fix(#386): prevent work-issue fatal token init error

### DIFF
--- a/tests/unit/test_llm_client_token_resolution.py
+++ b/tests/unit/test_llm_client_token_resolution.py
@@ -1,0 +1,41 @@
+from types import SimpleNamespace
+
+from agents.llm_client import LLMClientFactory
+
+
+def test_resolve_github_api_key_prefers_non_placeholder_config(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_PAT", raising=False)
+    LLMClientFactory._cached_github_token = None
+
+    resolved = LLMClientFactory.resolve_github_api_key("ghp_config_token")
+
+    assert resolved == "ghp_config_token"
+
+
+def test_resolve_github_api_key_uses_env_when_placeholder(monkeypatch):
+    monkeypatch.setenv("GH_TOKEN", "ghp_env_token")
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_PAT", raising=False)
+    LLMClientFactory._cached_github_token = None
+
+    resolved = LLMClientFactory.resolve_github_api_key("your-api-key-here")
+
+    assert resolved == "ghp_env_token"
+
+
+def test_resolve_github_api_key_falls_back_to_gh_auth_token(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_PAT", raising=False)
+    LLMClientFactory._cached_github_token = None
+
+    def fake_run(*args, **kwargs):
+        return SimpleNamespace(returncode=0, stdout="ghp_cli_token\n")
+
+    monkeypatch.setattr("agents.llm_client.subprocess.run", fake_run)
+
+    resolved = LLMClientFactory.resolve_github_api_key("your-api-key-here")
+
+    assert resolved == "ghp_cli_token"


### PR DESCRIPTION
# Summary
Prevents `work-issue` runtime initialization failures caused by missing exported GitHub token env vars by adding robust token resolution and preflight bootstrap.

## Goal / Context
- [x] Eliminate fatal GitHub Models init traceback when users are already authenticated with `gh auth`.
- [x] Keep token handling secure and environment-first while supporting CLI fallback.

## Acceptance Criteria
- [x] `LLMClientFactory` resolves token from config/env and falls back to `gh auth token`.
- [x] `scripts/work-issue.py` preflight reports token availability and bootstraps `GH_TOKEN` when possible.
- [x] Dry-run initialization succeeds without manual env export when `gh auth` is present.
- [x] Targeted unit tests cover token resolution behavior.

## Validation Evidence
- [x] `./.venv/bin/python -m pytest tests/unit/test_llm_client_token_resolution.py -q` → `3 passed`
- [x] `./.venv/bin/python scripts/work-issue.py --issue 217 --dry-run` → agent initialized successfully (no fatal token traceback)

## Repo Hygiene / Safety
- [x] Scope limited to token handling and tests (`agents/llm_client.py`, `scripts/work-issue.py`, `tests/unit/test_llm_client_token_resolution.py`)
- [x] No secrets committed
- [x] No workflow files changed

## Goal / Acceptance Criteria (required)
- [x] Runtime token fallback implemented and validated
- [x] Preflight token check improved with actionable status
- [x] Regression tests added

## Issue / Tracking Link (required)
Fixes: #386

## Validation (required)
- `./.venv/bin/python -m pytest tests/unit/test_llm_client_token_resolution.py -q`
- `./.venv/bin/python scripts/work-issue.py --issue 217 --dry-run`

## Automated checks
- Evidence: Targeted unit tests and dry-run initialization both pass.

## Manual test evidence (required)
- Evidence: Re-ran the previously failing path (`work-issue --dry-run`) and observed successful initialization with token detected from env/gh-auth fallback.
