### PR TITLE
fix(policy): enforce baseline-25 max-issues semantics (closes #394)

### DIFF
--- a/.github/prompts/agents/continue-backend.md
+++ b/.github/prompts/agents/continue-backend.md
@@ -29,7 +29,8 @@ Primary command:
 Default cap policy:
 
 - Default run limit is `25` issues.
-- If `--max-issues` is set above `25`, the script asks for explicit override confirmation.
+- `--max-issues` values below `25` are forbidden.
+- Values above `25` are allowed only with explicit runtime override confirmation.
 
 **Hard Rules:**
 

--- a/.github/prompts/modules/continue-backend-workflow.md
+++ b/.github/prompts/modules/continue-backend-workflow.md
@@ -9,7 +9,8 @@ Entry command:
 Limit policy:
 
 - Default `max-issues` per run is `25`.
-- Values above `25` require explicit runtime confirmation.
+- Values below `25` are forbidden.
+- Values above `25` require explicit runtime override confirmation.
 
 ## Loop
 

--- a/scripts/check_continue_backend_policy.py
+++ b/scripts/check_continue_backend_policy.py
@@ -4,7 +4,8 @@
 Enforces:
 - default max issues is 25
 - cap is 25
-- values above cap require explicit override confirmation
+- values below 25 are forbidden
+- values above baseline require explicit override confirmation
 """
 
 from __future__ import annotations
@@ -32,8 +33,9 @@ def _check_loop_file(path: Path, errors: list[str]) -> None:
 
     _must_contain(path, "MAX_ISSUES=25", errors)
     _must_contain(path, "MAX_ISSUES_CAP=25", errors)
+    _must_contain(path, 'if [[ "$MAX_ISSUES" -lt "$MAX_ISSUES_CAP" ]]', errors)
     _must_contain(path, 'if [[ "$MAX_ISSUES" -gt "$MAX_ISSUES_CAP" ]]', errors)
-    _must_contain(path, "Override cap and continue? (y/N):", errors)
+    _must_contain(path, "Override baseline and continue", errors)
 
 
 def main() -> int:

--- a/scripts/continue-phase-3.sh
+++ b/scripts/continue-phase-3.sh
@@ -67,11 +67,17 @@ if ! [[ "$MAX_ISSUES" =~ ^[0-9]+$ ]]; then
   exit 1
 fi
 
+if [[ "$MAX_ISSUES" -lt "$MAX_ISSUES_CAP" ]]; then
+  echo "--max-issues values below $MAX_ISSUES_CAP are forbidden." >&2
+  echo "Use --max-issues $MAX_ISSUES_CAP (default), or set a value above it and confirm override." >&2
+  exit 1
+fi
+
 if [[ "$MAX_ISSUES" -gt "$MAX_ISSUES_CAP" ]]; then
-  echo "Requested --max-issues=$MAX_ISSUES exceeds default cap ($MAX_ISSUES_CAP)."
-  read -r -p "Override cap and continue? (y/N): " override_cap
+  echo "Requested --max-issues=$MAX_ISSUES exceeds hard baseline ($MAX_ISSUES_CAP)."
+  read -r -p "Override baseline and continue with $MAX_ISSUES issues? (y/N): " override_cap
   if [[ ! "$override_cap" =~ ^[Yy]$ ]]; then
-    echo "Cancelled. Re-run with --max-issues <= $MAX_ISSUES_CAP or confirm override."
+    echo "Cancelled. Re-run with --max-issues $MAX_ISSUES_CAP or confirm override."
     exit 1
   fi
 fi
@@ -143,6 +149,9 @@ while true; do
   count=$((count + 1))
   if [[ "$count" -ge "$MAX_ISSUES" ]]; then
     echo "Reached --max-issues=$MAX_ISSUES; stopping."
+    if [[ "$MAX_ISSUES" -eq "$MAX_ISSUES_CAP" ]]; then
+      echo "If more backend issues remain, re-run with --max-issues > $MAX_ISSUES_CAP and confirm override."
+    fi
     break
   fi
 done

--- a/tests/unit/test_check_continue_backend_policy.py
+++ b/tests/unit/test_check_continue_backend_policy.py
@@ -23,8 +23,9 @@ def test_continue_backend_policy_checker_passes_with_required_snippets(tmp_path:
             [
                 "MAX_ISSUES=25",
                 "MAX_ISSUES_CAP=25",
+                'if [[ "$MAX_ISSUES" -lt "$MAX_ISSUES_CAP" ]]',
                 'if [[ "$MAX_ISSUES" -gt "$MAX_ISSUES_CAP" ]]',
-                "Override cap and continue? (y/N):",
+                "Override baseline and continue",
             ]
         ),
         encoding="utf-8",


### PR DESCRIPTION
## Goal / Context
- Enforce the intended max-issues semantics for backend continuation loops.
- Keep baseline at `25`, forbid values below baseline, and allow values above baseline only with explicit runtime confirmation.

## Acceptance Criteria
- [x] `scripts/continue-backend.sh` rejects `--max-issues < 25`.
- [x] `scripts/continue-phase-3.sh` rejects `--max-issues < 25`.
- [x] Both scripts prompt for explicit confirmation when `--max-issues > 25`.
- [x] Policy checker and unit tests are aligned with the updated behavior.
- [x] Prompt/module docs reflect the same policy contract.

## Validation Evidence
- [x] Ran `bash -n scripts/continue-backend.sh && bash -n scripts/continue-phase-3.sh`.
- [x] Ran `./.venv/bin/python -m pytest tests/unit/test_check_continue_backend_policy.py -q` (2 passed).
- [x] Ran `./scripts/validate_prompts.sh` (all checks passed).
- [x] Verified `./continue-backend --max-issues 24 --dry-run` fails.
- [x] Verified `printf 'n\n' | ./continue-backend --max-issues 26 --dry-run` prompts and exits.
- [x] Verified `printf 'n\n' | ./scripts/continue-phase-3.sh --max-issues 26 --dry-run` prompts and exits.

## Repo Hygiene / Safety
- [x] Changes are limited to policy scripts, checker/tests, and policy prompt docs.
- [x] No secrets or local-only config files added.
- [x] No unrelated generated artifacts included.

Closes #394
