### PR TITLE
feat(audit): deterministic cross-artifact rule pack v1 (fixes #389)

### DIFF
--- a/apps/api/services/audit/rules_engine.py
+++ b/apps/api/services/audit/rules_engine.py
@@ -58,6 +58,8 @@ class AuditRulesEngine:
                 issues.extend(rule_issues)
                 rule_violations[rule_name] = len(rule_issues)
 
+        issues = self._sort_issues(issues)
+
         # Calculate completeness score
         completeness_score = self._calculate_completeness_score(
             project_key, git_manager
@@ -69,6 +71,20 @@ class AuditRulesEngine:
             "rule_violations": rule_violations,
             "total_issues": len(issues),
         }
+
+    def _sort_issues(self, issues: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Return issues in deterministic order for stable outputs."""
+
+        def sort_key(issue: Dict[str, Any]) -> tuple:
+            return (
+                str(issue.get("rule", "")),
+                str(issue.get("severity", "")),
+                str(issue.get("artifact", "")),
+                str(issue.get("item_id", issue.get("milestone_id", ""))),
+                str(issue.get("message", "")),
+            )
+
+        return sorted(issues, key=sort_key)
 
     def compute_resource_hash(self, content: str) -> str:
         """Compute SHA-256 hash of resource content for compliance tracking."""

--- a/docs/api/audit-rule-pack-v1.md
+++ b/docs/api/audit-rule-pack-v1.md
@@ -1,0 +1,38 @@
+# Audit Rule Pack v1 (Cross-Artifact)
+
+This note summarizes the first backend cross-artifact audit rule pack introduced for Step 3 hardening.
+
+## Rules
+
+- `cross_reference`
+  - Validates RAID `related_deliverables` references against deliverables in `artifacts/pmp.json`.
+  - Emits an error when a referenced deliverable does not exist.
+
+- `date_consistency`
+  - Validates milestone `due_date` values in `artifacts/pmp.json` against project start/end dates from `metadata.json`.
+  - Emits an error for dates before project start and a warning for dates after project end.
+
+- `owner_validation`
+  - Validates RAID `owner` values against governance team IDs in `artifacts/governance.json`.
+  - Emits a warning when owner identifiers are unknown.
+
+- `dependency_cycles`
+  - Detects cycles in deliverable dependency graphs defined in `artifacts/pmp.json`.
+  - Emits an error for detected cycles.
+
+## Deterministic Output Behavior
+
+Audit issues are sorted deterministically before being returned, using stable keys:
+
+1. `rule`
+2. `severity`
+3. `artifact`
+4. `item_id` / `milestone_id`
+5. `message`
+
+This ensures identical input data produces identical issue ordering and messages across runs.
+
+## Validation Commands
+
+- `./.venv/bin/python -m pytest tests/unit/test_audit_service.py -k "audit and cross" -q`
+- `./.venv/bin/python -m pytest tests/integration/test_audit_rules.py -q`


### PR DESCRIPTION
## Goal / Context
- Complete Step 3 issue #389 by hardening cross-artifact audit outputs for deterministic ordering.
- Document the v1 cross-artifact audit rule pack in backend docs.

## Acceptance Criteria
- [x] New rules execute in current audit flow.
- [x] Rule outputs are deterministic for identical input.
- [x] Unit tests cover pass/fail paths.

## Validation Evidence
- [x] `PYTHONPATH=apps/api:. ./.venv/bin/python -m pytest tests/unit/test_audit_service.py -k "deterministic or cross_reference or date_consistency or dependency_cycle_detection" -q`
  - Result: `4 passed, 15 deselected`
- [x] `./.venv/bin/python -m pytest tests/integration/test_audit_rules.py -q`
  - Result: `8 passed`
- [x] `./.venv/bin/python -m black --check apps/api/services/audit/rules_engine.py tests/unit/test_audit_service.py`
  - Result: unchanged
- [x] `./.venv/bin/python -m flake8 apps/api/services/audit/rules_engine.py tests/unit/test_audit_service.py`
  - Result: passed

## Repo Hygiene / Safety
- [x] Only issue-scoped files changed:
  - `apps/api/services/audit/rules_engine.py`
  - `tests/unit/test_audit_service.py`
  - `docs/api/audit-rule-pack-v1.md`
- [x] No sensitive/config-local files changed (`projectDocs/`, `configs/llm.json`).
- [x] No unrelated refactors.

Fixes #389
