### PR TITLE
docs(ci): document local docs-sync gate usage (fixes #390)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -525,6 +525,17 @@ Tests run automatically in CI via `.github/workflows/ci.yml`:
 
 See `tests/README.md` for detailed testing documentation.
 
+#### Docs Sync Gate (Backend)
+
+Backend CI includes a docs-sync quality gate that validates `tests/README.md` against the
+current backend test structure.
+
+Run it locally before opening a PR that changes tests or test documentation:
+
+```bash
+./.venv/bin/python scripts/check_test_docs.py
+```
+
 ### Manual Testing
 
 1. **Start the API:**

--- a/tests/README.md
+++ b/tests/README.md
@@ -93,6 +93,12 @@ bash scripts/run_pytest_coverage.sh --local-stable
 - Backend quality gates run in `.github/workflows/ci-backend.yml` (tests, coverage, docs sync, lint, security, etc.).
 - The separate `.github/workflows/ci.yml` workflow is intentionally PR-meta/hygiene only.
 
+Run the docs-sync gate locally before pushing changes that touch tests or test docs:
+
+```bash
+./.venv/bin/python scripts/check_test_docs.py
+```
+
 ## TUI E2E notes
 
 `tests/e2e/tui/` starts a session-scoped backend for the suite and binds it to a dynamically chosen free localhost port (to avoid CI port conflicts).


### PR DESCRIPTION
## Goal / Context
- Complete issue #390 by ensuring contributors have a documented local command for the backend docs-sync gate.
- Keep docs and CI gate usage aligned to prevent drift between test structure and `tests/README.md`.

## Acceptance Criteria
- [x] CI fails when required test-doc sections are missing.
- [x] CI passes when docs are aligned.
- [x] Local command is documented for contributors.

## Validation Evidence
- [x] `./.venv/bin/python scripts/check_test_docs.py`
  - Result: `Documentation sync check PASSED`
- [x] `PYTHONPATH=apps/api:. ./.venv/bin/python -m pytest tests/unit -k "doc or checker" -q`
  - Result: `8 passed, 392 deselected`
- [x] `./.venv/bin/python -m pytest tests/ci -q`
  - Result: `15 passed`

## Repo Hygiene / Safety
- [x] Only issue-scoped docs files changed:
  - `tests/README.md`
  - `docs/development.md`
- [x] No sensitive/config-local files changed (`projectDocs/`, `configs/llm.json`).
- [x] No unrelated code refactors.

Fixes #390
