### PR TITLE
feat(agent): add max-RPS throttle for LLM calls

### DIFF
--- a/docs/agents/AUTONOMOUS-AGENT-GUIDE.md
+++ b/docs/agents/AUTONOMOUS-AGENT-GUIDE.md
@@ -217,6 +217,20 @@ Edit `configs/llm.json`:
 }
 ```
 
+### Request Throttle (Rate-Limit Protection)
+
+The agent applies a process-local throttle to **all outbound LLM calls** (planning, coding, review) by default.
+
+- `WORK_ISSUE_MAX_RPS` (default: `0.2`) → hard max requests/second (5 seconds minimum spacing)
+- `WORK_ISSUE_RPS_JITTER` (default: `0.1`) → adds up to 10% positive jitter per request to reduce burst alignment
+
+Example:
+
+```bash
+export WORK_ISSUE_MAX_RPS=0.25
+export WORK_ISSUE_RPS_JITTER=0.15
+```
+
 **Available Models (all free on GitHub):**
 
 ---

--- a/tests/agents/test_llm_client_rate_limit.py
+++ b/tests/agents/test_llm_client_rate_limit.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Unit tests for LLM request throttle and env configuration."""
+
+from agents.llm_client import LLMClientFactory, _LLMRequestThrottle
+
+
+class _FakeClock:
+    def __init__(self):
+        self.now_value = 0.0
+        self.sleeps: list[float] = []
+
+    def now(self) -> float:
+        return self.now_value
+
+    async def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.now_value += seconds
+
+
+def test_rps_settings_use_safe_defaults(monkeypatch):
+    monkeypatch.delenv("WORK_ISSUE_MAX_RPS", raising=False)
+    monkeypatch.delenv("WORK_ISSUE_RPS_JITTER", raising=False)
+
+    max_rps, jitter_ratio = LLMClientFactory._get_rps_settings()
+
+    assert max_rps == 0.2
+    assert jitter_ratio == 0.1
+
+
+def test_rps_settings_fallback_for_invalid_values(monkeypatch):
+    monkeypatch.setenv("WORK_ISSUE_MAX_RPS", "0")
+    monkeypatch.setenv("WORK_ISSUE_RPS_JITTER", "not-a-number")
+
+    max_rps, jitter_ratio = LLMClientFactory._get_rps_settings()
+
+    assert max_rps == 0.2
+    assert jitter_ratio == 0.1
+
+
+async def test_throttle_enforces_min_interval_without_jitter():
+    fake = _FakeClock()
+    throttle = _LLMRequestThrottle(
+        max_rps=2.0,
+        jitter_ratio=0.0,
+        clock=fake.now,
+        sleeper=fake.sleep,
+        jitter_fn=lambda low, high: 0.0,
+    )
+
+    await throttle.acquire()
+    await throttle.acquire()
+    await throttle.acquire()
+
+    assert fake.sleeps == [0.5, 0.5]
+
+
+async def test_throttle_adds_positive_jitter_without_breaking_max_rps():
+    fake = _FakeClock()
+    throttle = _LLMRequestThrottle(
+        max_rps=1.0,
+        jitter_ratio=0.2,
+        clock=fake.now,
+        sleeper=fake.sleep,
+        jitter_fn=lambda low, high: high,
+    )
+
+    await throttle.acquire()
+    await throttle.acquire()
+
+    assert len(fake.sleeps) == 1
+    assert fake.sleeps[0] == 1.2
+
+
+def test_shared_throttle_reuses_instance_for_same_settings(monkeypatch):
+    monkeypatch.setenv("WORK_ISSUE_MAX_RPS", "0.25")
+    monkeypatch.setenv("WORK_ISSUE_RPS_JITTER", "0.2")
+
+    LLMClientFactory._shared_request_throttle = None
+    LLMClientFactory._shared_request_throttle_key = None
+
+    first = LLMClientFactory._get_shared_request_throttle()
+    second = LLMClientFactory._get_shared_request_throttle()
+
+    assert first is second


### PR DESCRIPTION
## Goal / Context
- Complete issue #400 by enforcing a configurable max-RPS throttle for all outbound LLM calls.
- Reduce GitHub Models 429 bursts by adding positive jitter while preserving a hard minimum request interval.

## Acceptance Criteria
- [x] A configurable max-RPS throttle is enforced for all LLM calls (planning, coding, review).
- [x] Env var documented (`WORK_ISSUE_MAX_RPS`) with a safe default.
- [x] Throttle includes jitter to avoid burst alignment.
- [x] Unit tests validate minimum delay / rate enforcement.
- [x] No changes to existing functionality (unless intentional).
- [x] API documented in OpenAPI schema (if applicable; N/A).
- [x] No sensitive data committed (`projectDocs/`, `configs/llm.json`).

## Validation Evidence
- [x] `./.venv/bin/python -m black agents/llm_client.py tests/agents/test_llm_client_rate_limit.py`
  - Result: `1 file reformatted, 1 file unchanged`
- [x] `./.venv/bin/python -m flake8 agents/llm_client.py tests/agents/test_llm_client_rate_limit.py`
  - Result: no lint errors
- [x] `./.venv/bin/python -m pytest tests/agents/test_llm_client_rate_limit.py -q --tb=short`
  - Result: `5 passed`

## Repo Hygiene / Safety
- [x] Only issue-scoped files changed:
  - `agents/llm_client.py`
  - `tests/agents/test_llm_client_rate_limit.py`
  - `docs/agents/AUTONOMOUS-AGENT-GUIDE.md`
- [x] No sensitive/config-local files changed (`projectDocs/`, `configs/llm.json`).
- [x] No unrelated refactors.

Fixes #400
