### PR TITLE
feat(agent): enforce 20-minute planning guardrail

### DIFF
--- a/docs/WORK-ISSUE-WORKFLOW.md
+++ b/docs/WORK-ISSUE-WORKFLOW.md
@@ -61,6 +61,20 @@ Recommended practice:
 - Keep planning/review packets concise and scoped to touched files.
 - Keep workflow-file changes (`.github/workflows/*.yml`) in dedicated PRs with appropriate merge scope.
 
+## Planning Guardrail (20-Minute Manual Limit)
+
+To keep issue slices small and reviewable, planning output must include a manual-effort estimate:
+
+- `ESTIMATED_MANUAL_MINUTES: <integer>`
+- `SPLIT_REQUIRED: YES|NO`
+- `SPLIT_RECOMMENDATION: <actionable split>` (required when split is needed)
+
+Execution guard behavior:
+
+- If `ESTIMATED_MANUAL_MINUTES > 20`, execution stops before coding/review phases.
+- If estimate is missing, execution also stops (conservative fail-safe).
+- The agent prints a split recommendation to drive creation of smaller follow-up issues.
+
 ## Goal Archive Behavior (`.tmp`)
 
 `scripts/work-issue.py` now archives issue goals from `.tmp/*.md` automatically:

--- a/docs/agents/AUTONOMOUS-AGENT-GUIDE.md
+++ b/docs/agents/AUTONOMOUS-AGENT-GUIDE.md
@@ -231,6 +231,22 @@ export WORK_ISSUE_MAX_RPS=0.25
 export WORK_ISSUE_RPS_JITTER=0.15
 ```
 
+### Planning Guardrail (20-Minute Limit)
+
+The planning phase enforces a hard manual-work guardrail before implementation starts.
+
+- Planner output must include `ESTIMATED_MANUAL_MINUTES`.
+- If estimate is `> 20`, execution halts before coding and prints a split recommendation.
+- If estimate is missing, execution also halts (conservative split-required behavior).
+
+Expected planning block:
+
+```text
+ESTIMATED_MANUAL_MINUTES: 15
+SPLIT_REQUIRED: NO
+SPLIT_RECOMMENDATION: <short split plan when SPLIT_REQUIRED is YES>
+```
+
 **Available Models (all free on GitHub):**
 
 ---

--- a/tests/agents/test_autonomous_workflow_agent_guardrail.py
+++ b/tests/agents/test_autonomous_workflow_agent_guardrail.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Unit tests for autonomous planning 20-minute guardrail behavior."""
+
+from agents.autonomous_workflow_agent import AutonomousWorkflowAgent
+
+
+def test_extract_estimated_manual_minutes_parses_integer_field():
+    plan_text = """
+PLANNING_GUARDRAIL:
+ESTIMATED_MANUAL_MINUTES: 18
+SPLIT_REQUIRED: NO
+"""
+    assert AutonomousWorkflowAgent._extract_estimated_manual_minutes(plan_text) == 18
+
+
+def test_extract_estimated_manual_minutes_returns_none_when_missing():
+    plan_text = "HANDOFF_TO_CODING:\n- Steps: ..."
+    assert AutonomousWorkflowAgent._extract_estimated_manual_minutes(plan_text) is None
+
+
+def test_evaluate_manual_plan_guardrail_blocks_when_over_limit():
+    agent = AutonomousWorkflowAgent(issue_number=401, dry_run=True)
+    ok, estimate, message = agent._evaluate_manual_plan_guardrail(
+        "ESTIMATED_MANUAL_MINUTES: 35"
+    )
+
+    assert ok is False
+    assert estimate == 35
+    assert "exceeding 20-minute limit" in message
+
+
+def test_evaluate_manual_plan_guardrail_blocks_when_missing_estimate():
+    agent = AutonomousWorkflowAgent(issue_number=401, dry_run=True)
+    ok, estimate, message = agent._evaluate_manual_plan_guardrail("SPLIT_REQUIRED: NO")
+
+    assert ok is False
+    assert estimate is None
+    assert "missing ESTIMATED_MANUAL_MINUTES" in message
+
+
+def test_evaluate_manual_plan_guardrail_allows_within_limit():
+    agent = AutonomousWorkflowAgent(issue_number=401, dry_run=True)
+    ok, estimate, message = agent._evaluate_manual_plan_guardrail(
+        "ESTIMATED_MANUAL_MINUTES: 20"
+    )
+
+    assert ok is True
+    assert estimate == 20
+    assert "within 20-minute limit" in message
+
+
+def test_build_split_recommendation_prefers_planner_block():
+    agent = AutonomousWorkflowAgent(issue_number=401, dry_run=True)
+    plan_text = """
+ESTIMATED_MANUAL_MINUTES: 28
+SPLIT_RECOMMENDATION:
+- Create issue 401A for parser prep.
+- Create issue 401B for implementation.
+HANDOFF_TO_CODING:
+- Summary: ...
+"""
+
+    recommendation = agent._build_split_recommendation(plan_text, estimate=28)
+
+    assert "401A" in recommendation
+    assert "401B" in recommendation
+
+
+def test_build_split_recommendation_falls_back_when_missing():
+    agent = AutonomousWorkflowAgent(issue_number=401, dry_run=True)
+    recommendation = agent._build_split_recommendation(
+        "ESTIMATED_MANUAL_MINUTES: 30", estimate=30
+    )
+
+    assert "Current plan estimate: 30 minutes" in recommendation
+    assert "Create issue A" in recommendation


### PR DESCRIPTION
## Goal / Context
- Complete issue #401 by enforcing a 20-minute manual-work planning guardrail before coding starts.
- Stop oversized plans early and provide explicit split guidance to keep issue slices reviewable.

## Acceptance Criteria
- [x] Planner output includes an estimated manual time field.
- [x] Execution is stopped when estimate > 20 minutes.
- [x] A clear split recommendation is printed for next issues.
- [x] Unit tests validate parsing and guard decisions.
- [x] No changes to existing functionality (unless intentional).
- [x] API documented in OpenAPI schema (if applicable; N/A).
- [x] No sensitive data committed (`projectDocs/`, `configs/llm.json`).

## Validation Evidence
- [x] `./.venv/bin/python -m black agents/autonomous_workflow_agent.py tests/agents/test_autonomous_workflow_agent_guardrail.py`
  - Result: `1 file reformatted, 1 file unchanged`
- [x] `./.venv/bin/python -m pytest tests/agents/test_autonomous_workflow_agent_guardrail.py -q --tb=short`
  - Result: `7 passed`

## Repo Hygiene / Safety
- [x] Only issue-scoped files changed:
  - `agents/autonomous_workflow_agent.py`
  - `tests/agents/test_autonomous_workflow_agent_guardrail.py`
  - `docs/WORK-ISSUE-WORKFLOW.md`
  - `docs/agents/AUTONOMOUS-AGENT-GUIDE.md`
- [x] No sensitive/config-local files changed (`projectDocs/`, `configs/llm.json`).
- [x] No unrelated refactors.

Fixes #401
