### PR TITLE
ci: add web UI guardrails

### DIFF
--- a/.github/workflows/cd-backend.yml
+++ b/.github/workflows/cd-backend.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
     paths:
       - 'apps/api/**'
-      - 'apps/web/**'
       - 'docker/api/**'
       - 'docker/web/**'
       - 'docker-compose.yml'

--- a/.github/workflows/ci-web-ui.yml
+++ b/.github/workflows/ci-web-ui.yml
@@ -1,0 +1,67 @@
+name: Web UI Guardrails
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docker/web/**'
+      - 'docker-compose.yml'
+      - '.gitmodules'
+      - '.gitignore'
+      - 'README.md'
+      - 'QUICKSTART.md'
+      - '_external/AI-Agent-Framework-Client'
+  push:
+    branches: [main]
+    paths:
+      - 'docker/web/**'
+      - 'docker-compose.yml'
+      - '.gitmodules'
+      - '.gitignore'
+      - 'README.md'
+      - 'QUICKSTART.md'
+      - '_external/AI-Agent-Framework-Client'
+
+jobs:
+  guardrails:
+    name: Guardrails + Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Enforce canonical UI sources
+        shell: bash
+        run: |
+          set -euo pipefail
+          if grep -R "apps/web" docker/web/Dockerfile; then
+            echo "apps/web is not allowed in docker/web/Dockerfile"
+            exit 1
+          fi
+
+          if ! git submodule status _external/AI-Agent-Framework-Client >/dev/null 2>&1; then
+            echo "_external/AI-Agent-Framework-Client must be a git submodule"
+            exit 1
+          fi
+
+          if ! test -f .gitmodules; then
+            echo ".gitmodules missing; client submodule not configured"
+            exit 1
+          fi
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: _external/AI-Agent-Framework-Client/client/package-lock.json
+
+      - name: Install client dependencies
+        working-directory: _external/AI-Agent-Framework-Client/client
+        run: npm ci
+
+      - name: Build client
+        working-directory: _external/AI-Agent-Framework-Client/client
+        run: npm run build

--- a/.github/workflows/reusable-ghcr-publish.yml
+++ b/.github/workflows/reusable-ghcr-publish.yml
@@ -47,6 +47,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Goal / Context
Add CI/CD guardrails so the web image can only be built from the canonical client UI and never from apps/web. This enforces the migration in #420.

Depends on #419.

## Acceptance Criteria
- [x] CD checks out submodules for web builds.
- [x] Guardrail workflow fails if docker/web/Dockerfile references apps/web.
- [x] Guardrail workflow verifies the client submodule exists.
- [x] Canonical client build runs in CI for relevant changes.
- [x] No changes to existing functionality (unless intentional).
- [x] No sensitive data committed (projectDocs/, configs/llm.json).

## Validation Evidence
- [x] Not run (workflow-only change; CI will validate).

## Repo Hygiene / Safety
- [x] No changes to `projectDocs/` or `configs/llm.json`.
