### PR TITLE
feat: context7 integration hardening and setup docs (#426)

### DIFF
--- a/.github/prompts/drafting-issue.md
+++ b/.github/prompts/drafting-issue.md
@@ -40,7 +40,13 @@ Please help me draft a complete issue including:
    - Potential gotchas or tricky areas
    - References to similar existing code
 
-6. **Estimated Size**: S (< 50 lines) / M (50-200 lines) / L (> 200 lines)
+6. **Docs Grounding (MCP + Context7)**:
+   - List framework/library versions in scope (e.g., FastAPI 0.109.1, Pydantic 2.5.3)
+   - Require Context7-backed doc retrieval for API/SDK behavior questions
+   - Specify: “Use repo conventions for architecture, use Context7 for external API correctness”
+   - Include a short note for any unresolved version ambiguity
+
+7. **Estimated Size**: S (< 50 lines) / M (50-200 lines) / L (> 200 lines)
 
 Format as a GitHub issue ready to copy-paste.
 ```
@@ -104,6 +110,12 @@ python -m black apps/api/
 python -m flake8 apps/api/
 ```
 
+## Docs Grounding (MCP + Context7)
+- Libraries in scope: FastAPI 0.109.1, Pydantic 2.5.3, GitPython 3.1.41
+- External API behavior must be validated against Context7-provided docs
+- Repo architecture decisions must follow DDD and local project conventions
+- If docs are ambiguous across versions, capture assumptions in issue notes
+
 ## Implementation Notes
 - Add new route in `apps/api/routers/projects.py`
 - Use existing `GitManager` to read artifacts
@@ -124,6 +136,7 @@ python -m flake8 apps/api/
 - Be specific about what changes and what doesn't
 - Include both happy path and error cases
 - Make validation steps copy-pasteable
+- Add a Context7 docs-grounding note for any non-trivial framework/API behavior
 - Link to related issues for context
 - Consider backwards compatibility
 - Note any environment variables or config needed

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This system provides intelligent project management following ISO 21500 standard
 
 - 🚀 **[Quick Start Guide](QUICKSTART.md)** - Get up and running in 10 minutes
 - 🧰 **[Install & LLM Setup Guide](docs/howto/install-and-llm-setup.md)** - Docker images, local setup, and provider configuration examples
+- 🧩 **[Context7 MCP Setup (VS Code + Docker)](docs/howto/context7-vscode-docker.md)** - Persistent docs-grounding setup with boot-time startup
 - 📚 **[Tutorials](docs/tutorials/README.md)** - NEW! Step-by-step learning paths for all skill levels
 - � **[Issue Agent Chat](ISSUEAGENT-CHAT-SETUP.md)** - Run autonomous agent from VS Code chat
 - 🤝 **[Contributing Guide](docs/CONTRIBUTING.md)** - How to contribute to the project

--- a/docker-compose.context7.yml
+++ b/docker-compose.context7.yml
@@ -1,0 +1,12 @@
+services:
+  context7:
+    build:
+      context: .
+      dockerfile: docker/context7/Dockerfile
+    container_name: context7-mcp
+    restart: unless-stopped
+    environment:
+      - CONTEXT7_PORT=3010
+      - CONTEXT7_API_KEY=${CONTEXT7_API_KEY:-}
+    ports:
+      - "127.0.0.1:3010:3010"

--- a/docker/context7/Dockerfile
+++ b/docker/context7/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:20-alpine
+
+RUN npm install -g @upstash/context7-mcp@2.1.2
+
+EXPOSE 3010
+
+ENV CONTEXT7_PORT=3010
+
+CMD ["sh", "-c", "context7-mcp --transport http --port ${CONTEXT7_PORT} ${CONTEXT7_API_KEY:+--api-key ${CONTEXT7_API_KEY}}"]

--- a/docs/howto/context7-vscode-docker.md
+++ b/docs/howto/context7-vscode-docker.md
@@ -1,0 +1,68 @@
+# Context7 Setup for VS Code + Docker (Persistent)
+
+This guide installs Context7 for VS Code, runs a local Context7 MCP endpoint in Docker, and enables host boot startup.
+
+## 1) Install VS Code Extension
+
+```bash
+code --install-extension upstash.context7-mcp
+```
+
+## 2) Configure API Key (recommended)
+
+Context7 works without a key, but rate limits are better with one.
+
+```bash
+echo 'export CONTEXT7_API_KEY="YOUR_KEY_HERE"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+## 3) Start Local Context7 MCP via Docker
+
+From repository root:
+
+```bash
+docker compose -f docker-compose.context7.yml up -d --build
+```
+
+Validate endpoint:
+
+```bash
+curl -sS -i http://127.0.0.1:3010/mcp | head
+```
+
+Expected: HTTP response from MCP endpoint (typically `406 Not Acceptable` for plain curl, which indicates the MCP endpoint is live).
+
+## 4) Enable Startup at Host Boot (systemd)
+
+```bash
+chmod +x scripts/install-context7-systemd.sh
+./scripts/install-context7-systemd.sh
+```
+
+Check status:
+
+```bash
+sudo systemctl status context7-mcp.service
+docker ps --filter name=context7-mcp
+```
+
+## 5) VS Code MCP Configuration
+
+Workspace config is pre-added in `.vscode/settings.json`:
+
+- MCP server URL: `http://127.0.0.1:3010/mcp`
+- Header: `CONTEXT7_API_KEY` from `${env:CONTEXT7_API_KEY}`
+
+Reload VS Code window after setup:
+
+- Command Palette → `Developer: Reload Window`
+
+## Best-Practice Prompt Rule
+
+Add this in your team prompt conventions:
+
+```txt
+Always use Context7 for library/API docs, setup/configuration steps, and code generation where external framework behavior matters.
+Use repository conventions for architecture and internal implementation details.
+```

--- a/scripts/install-context7-systemd.sh
+++ b/scripts/install-context7-systemd.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+UNIT_NAME="context7-mcp.service"
+UNIT_PATH="/etc/systemd/system/${UNIT_NAME}"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker command not found. Install Docker first."
+  exit 1
+fi
+
+if ! command -v systemctl >/dev/null 2>&1; then
+  echo "systemctl not found. This script requires systemd."
+  exit 1
+fi
+
+sudo tee "${UNIT_PATH}" >/dev/null <<EOF
+[Unit]
+Description=Context7 MCP Docker Service
+After=docker.service network-online.target
+Requires=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=${ROOT_DIR}
+ExecStart=/usr/bin/docker compose -f ${ROOT_DIR}/docker-compose.context7.yml up -d
+ExecStop=/usr/bin/docker compose -f ${ROOT_DIR}/docker-compose.context7.yml down
+TimeoutStartSec=0
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now "${UNIT_NAME}"
+
+echo "Installed and started ${UNIT_NAME}."
+echo "Check status with: sudo systemctl status ${UNIT_NAME}"


### PR DESCRIPTION
## Summary
- add local Context7 docker compose service and Dockerfile
- add persistent host startup installer via systemd helper script
- add Context7 setup/howto documentation and README link
- add docs-grounding guidance in issue drafting template

## Validation
- docker compose -f docker-compose.context7.yml up -d --build
- curl -sS -i http://127.0.0.1:3010/mcp | head -n 14
- ./scripts/install-context7-systemd.sh

Fixes #426
