### PR TITLE
hardening(context7): persist systemd env file for API key

### DIFF
--- a/.github/prompts/drafting-issue.md
+++ b/.github/prompts/drafting-issue.md
@@ -43,7 +43,7 @@ Please help me draft a complete issue including:
 6. **Docs Grounding (MCP + Context7)**:
    - List framework/library versions in scope (e.g., FastAPI 0.109.1, Pydantic 2.5.3)
    - Require Context7-backed doc retrieval for API/SDK behavior questions
-   - Specify: “Use repo conventions for architecture, use Context7 for external API correctness”
+   - Specify explicitly: “Use repo conventions for architecture and internal implementation details; use Context7 for external API/library correctness”
    - Include a short note for any unresolved version ambiguity
 
 7. **Estimated Size**: S (< 50 lines) / M (50-200 lines) / L (> 200 lines)

--- a/docs/howto/context7-vscode-docker.md
+++ b/docs/howto/context7-vscode-docker.md
@@ -42,10 +42,20 @@ chmod +x scripts/install-context7-systemd.sh
 ./scripts/install-context7-systemd.sh
 ```
 
+The installer creates and uses `/etc/default/context7-mcp` for optional
+`CONTEXT7_API_KEY` persistence at boot.
+
+If needed, edit it manually:
+
+```bash
+sudoedit /etc/default/context7-mcp
+```
+
 Check status:
 
 ```bash
 sudo systemctl status context7-mcp.service
+sudo systemctl cat context7-mcp.service | grep EnvironmentFile
 docker ps --filter name=context7-mcp
 ```
 
@@ -88,6 +98,7 @@ docker inspect -f '{{ .HostConfig.RestartPolicy.Name }}' context7-mcp
 # Verify boot persistence after systemd install
 systemctl is-enabled context7-mcp.service
 systemctl is-active context7-mcp.service
+sudo systemctl cat context7-mcp.service | grep EnvironmentFile
 ```
 
 Expected outcomes:
@@ -97,3 +108,4 @@ Expected outcomes:
 - `docker inspect ... context7-mcp` returns `unless-stopped`.
 - `systemctl is-enabled` returns `enabled`.
 - `systemctl is-active` returns `active`.
+- `systemctl cat ... | grep EnvironmentFile` shows `/etc/default/context7-mcp`.


### PR DESCRIPTION
# Pull Request

## Goal / Context

- Links: Fixes #425
- Related client repo (if relevant): none
- Scope (what’s included / excluded):
  - Included: systemd installer environment persistence for optional `CONTEXT7_API_KEY`, Context7 setup/validation docs update, and prompt docs-grounding wording tighten.
  - Excluded: non-Context7 features, API/router/service logic changes, and client code changes.

## Acceptance Criteria (copy from the issue)

- [x] Local Context7 MCP endpoint runs on `127.0.0.1:3010/mcp` via Docker compose.
- [x] Service is configured for persistence (`restart: unless-stopped`) and boot-time startup via systemd helper.
- [x] VS Code workspace MCP config points to local endpoint and supports `CONTEXT7_API_KEY` via environment.
- [x] Documentation includes install, run, verify, and startup instructions.
- [x] Prompt templates include explicit docs-grounding guidance for external API/library behavior.
- [x] Validation commands and expected outcomes are documented and reproducible.

## Implementation Notes

- Updated `scripts/install-context7-systemd.sh`:
  - Adds `ENV_FILE=/etc/default/context7-mcp` handling.
  - Creates env file template (or writes current `CONTEXT7_API_KEY` if present).
  - Loads env via `EnvironmentFile=-/etc/default/context7-mcp` in generated unit.
- Updated `docs/howto/context7-vscode-docker.md`:
  - Documents `/etc/default/context7-mcp` management and verification command.
  - Adds expected outcome for `EnvironmentFile` validation.
- Updated `.github/prompts/drafting-issue.md`:
  - Tightens docs-grounding instruction to explicitly separate repo-convention architecture guidance vs Context7 external API correctness.
- API changes (endpoints/contracts): none.
- Cross-repo impact: none.

## Validation Evidence

Backend:

- [x] `./.venv/bin/python -m black apps/api/`
  - Evidence: `All done! ✨ 🍰 ✨` and `74 files left unchanged.`
- [x] `./.venv/bin/python -m flake8 apps/api/`
  - Evidence: command exits successfully with no violations.
- [x] `./.venv/bin/python -m pytest`
  - Evidence: `839 passed, 7 skipped, 34 deselected, 21 warnings in 146.35s`.

Issue-specific (`#425`):

- [x] `docker compose -f docker-compose.context7.yml up -d --build`
  - Evidence: image built and `context7-mcp` container started.
- [x] `curl -sS -i http://127.0.0.1:3010/mcp | head -n 14`
  - Evidence: `HTTP/1.1 406 Not Acceptable` (expected plain curl behavior for live MCP endpoint).
- [x] `docker compose -f docker-compose.context7.yml ps context7`
  - Evidence: `context7-mcp` shown as running with `127.0.0.1:3010->3010/tcp`.
- [x] `docker inspect -f '{{ .HostConfig.RestartPolicy.Name }}' context7-mcp`
  - Evidence: `unless-stopped`.

Frontend (changed files?):

- [x] Not touched in this issue; frontend lint/test/build not required.

## Repo Hygiene / Safety

- [x] `projectDocs/` is NOT committed
- [x] `configs/llm.json` is NOT committed
- [x] No secrets in code/logs

## How to review

1. Review `scripts/install-context7-systemd.sh` for env-file creation and unit `EnvironmentFile` wiring.
2. Review `docs/howto/context7-vscode-docker.md` for setup and validation command updates.
3. Review `.github/prompts/drafting-issue.md` docs-grounding wording adjustment.
4. Confirm validation outputs in this PR match command evidence.
5. Confirm scope remains Context7-only and no unrelated code paths changed.

## Screenshots / Logs (if relevant)

- N/A (CLI/script/docs-only changes).
