### PR TITLE
issue #491: shared gh throttle helper for Python automation

### DIFF
--- a/agents/autonomous_workflow_agent.py
+++ b/agents/autonomous_workflow_agent.py
@@ -30,6 +30,8 @@ from agent_framework.openai import OpenAIChatClient
 # Add parent to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from agents.tooling.gh_throttle import run_gh_throttled
+
 from agents.llm_client import LLMClientFactory
 from agents.tools import get_all_tools, get_shell_only_tools
 
@@ -185,7 +187,7 @@ class AutonomousWorkflowAgent:
             cmd.extend(["--repo", repo])
 
         try:
-            result = subprocess.run(
+            result = run_gh_throttled(
                 cmd,
                 capture_output=True,
                 text=True,

--- a/agents/tooling/gh_throttle.py
+++ b/agents/tooling/gh_throttle.py
@@ -1,0 +1,46 @@
+import os
+import subprocess
+import time
+from typing import Optional, Sequence
+
+
+_LAST_GH_CALL_TS: Optional[float] = None
+
+
+def _resolve_min_interval_seconds(override: Optional[int]) -> int:
+    if override is not None:
+        return int(override)
+    return int(os.environ.get("GH_MIN_INTERVAL_SECONDS", "1") or "1")
+
+
+def run_gh_throttled(
+    args: Sequence[str],
+    *,
+    min_interval_seconds: Optional[int] = None,
+    **subprocess_kwargs,
+) -> subprocess.CompletedProcess[str]:
+    """Run a `gh ...` command with a minimum interval between invocations.
+
+    This helps avoid secondary GitHub API rate limits when automation issues many
+    `gh` subprocess calls in a tight loop.
+
+    Configuration:
+    - `GH_MIN_INTERVAL_SECONDS` (default: 1)
+    - Or pass `min_interval_seconds` explicitly.
+    """
+
+    global _LAST_GH_CALL_TS
+
+    interval = _resolve_min_interval_seconds(min_interval_seconds)
+    if interval > 0 and _LAST_GH_CALL_TS is not None:
+        elapsed = time.monotonic() - _LAST_GH_CALL_TS
+        remaining = interval - elapsed
+        if remaining > 0:
+            time.sleep(remaining)
+
+    _LAST_GH_CALL_TS = time.monotonic()
+
+    return subprocess.run(  # noqa: S603 (controlled internal CLI invocation)
+        list(args),
+        **subprocess_kwargs,
+    )


### PR DESCRIPTION
# Summary
Fixes: #491

Adds a shared Python helper to throttle `gh` subprocess calls, reducing bursty GitHub API usage during automation runs.

## Goal / Acceptance Criteria (required)
- [x] Python `gh` calls in split-issue creation are throttled via `GH_MIN_INTERVAL_SECONDS`.
- [x] Python `gh` calls in planning issue-context fetch are throttled.
- [x] Default remains conservative (1s) and is configurable via env var.

## Issue / Tracking Link (required)
- Fixes: #491

## Validation (required)
- Evidence: `pytest tests/unit tests/integration -q`

## Automated checks
- Evidence: GitHub Actions check "backend-ci" succeeded on this PR.
- Evidence: GitHub Actions check "Process quality (prompts + issue specs)" succeeded on this PR.

## Manual test evidence (required)
- Evidence: Not applicable (script/tooling change only; no runtime behavior exposed via API/UI).
