### PR TITLE
issue #495: fix prmerge integer expression error

### DIFF
--- a/scripts/prmerge
+++ b/scripts/prmerge
@@ -293,8 +293,10 @@ detect_issue_type() {
         echo "docs"
     else
         # Check file patterns if title is ambiguous
-        local doc_count=$(echo "$files_changed" | grep -c '\.md$\|/docs/' || echo "0")
-        local test_count=$(echo "$files_changed" | grep -c 'test\|spec' || echo "0")
+        # NOTE: `grep -c` prints "0" even when it exits non-zero (no matches).
+        # Avoid `|| echo 0` which would append a second "0" and break numeric comparisons.
+        local doc_count=$(echo "$files_changed" | grep -cE '\.md$|/docs/' || true)
+        local test_count=$(echo "$files_changed" | grep -cE 'test|spec' || true)
         local total_files=$(echo "$files_changed" | wc -l)
         
         # If >50% doc files, it's a docs issue


### PR DESCRIPTION
# Summary
Fix `scripts/prmerge` issue-type detection so it never produces non-numeric count strings (which previously could trigger `[: 0 0: integer expression expected` and a non-zero exit).

## Goal / Acceptance Criteria (required)
- [x] `detect_issue_type()` computes doc/test file counts as plain integers
- [x] `./scripts/prmerge <issue>` no longer prints `integer expression expected` during metrics/type detection

## Issue / Tracking Link (required)
Fixes: #495

## Validation (required)
- `bash -n scripts/prmerge`
- Manual: merged PRs no longer show the bash integer-expression error in Step 4

## Automated checks
Evidence: GitHub Actions (if configured)

## Manual test evidence (required)
Evidence: Reproduced prior failure on merge; verified fix removes duplicate "0" output path