### PR TITLE
issue #497: prmerge non-interactive next-pr prompt

### DIFF
--- a/scripts/prmerge
+++ b/scripts/prmerge
@@ -1203,7 +1203,12 @@ echo "  3. Merge (squash) when ready"
 echo ""
 
 # Offer to run next-pr
-read -p "Run './next-pr' now? (Y/n): " run_next_pr
+run_next_pr="n"
+if [ -t 0 ]; then
+    # Interactive shell: ask the user.
+    read -p "Run './next-pr' now? (Y/n): " run_next_pr || run_next_pr="n"
+fi
+
 if [[ ! "$run_next_pr" =~ ^[Nn]$ ]]; then
     echo ""
     if [ -f "./scripts/next-pr.py" ]; then


### PR DESCRIPTION
# Summary
Make `scripts/prmerge` safe to run non-interactively (stdin not a TTY) by skipping the final `next-pr` prompt and tolerating EOF, so successful merges return exit code 0.

## Goal / Acceptance Criteria (required)
- [x] `prmerge` no longer fails at EOF on the final `read -p` prompt
- [x] Non-interactive runs (piped stdin) can complete successfully and exit 0

## Issue / Tracking Link (required)
Fixes: #497

## Validation (required)
- `bash -n scripts/prmerge`
- Manual: run `printf "y\n" | PRMERGE_ALLOW_NO_REQUIRED_CHECKS=1 PRMERGE_ALLOW_UNAPPROVED=1 ./scripts/prmerge <issue>` and confirm no EOF failure at the end

## Automated checks
Evidence: GitHub Actions (if configured)

## Manual test evidence (required)
Evidence: This PR targets non-interactive execution; verified logic skips prompt when stdin is not a TTY