### PR TITLE
issue #499: prmerge must not prompt when no PR exists

### DIFF
--- a/.github/prompts/agents/continue-backend.md
+++ b/.github/prompts/agents/continue-backend.md
@@ -17,7 +17,7 @@
 3. Publish backend roadmap issues idempotently.
 4. Select next scoped backend issue.
 5. Run `scripts/work-issue.py` with retry/backoff for rate-limit handling.
-6. Merge via `scripts/prmerge` after review/CI gates.
+6. Merge via `scripts/prmerge` after review/CI gates. If `prmerge` reports "No PR found" it is a complete answer (nothing to merge): do not prompt for a PR number; stop or move to next issue.
 7. Continue until stop condition.
 
 Primary command:

--- a/.github/prompts/agents/continue-phase-2.md
+++ b/.github/prompts/agents/continue-phase-2.md
@@ -17,7 +17,7 @@
 4. Ensure UX authority consultation evidence for UI-affecting changes.
 5. Run validations and fix failures.
 6. Run PR review using repository rubric and confirm approval status.
-7. Merge via `scripts/prmerge` only after review + CI pass.
+7. Merge via `scripts/prmerge` only after review + CI pass. If `prmerge` reports "No PR found" it is a complete answer (nothing to merge): do not prompt for a PR number; stop or move to next issue.
 8. Record outcome and continue with next issue until stop condition.
 
 Primary command:

--- a/.github/prompts/modules/continue-backend-workflow.md
+++ b/.github/prompts/modules/continue-backend-workflow.md
@@ -20,6 +20,10 @@ Limit policy:
 4. **Select:** pick next scoped backend issue (label-filtered by default).
 5. **Implement:** run `./scripts/work-issue.py --issue <n>` with retry/backoff.
 6. **Merge:** run `./scripts/prmerge <n>` after required checks.
+
+Merge rule:
+
+- If `prmerge` reports no PR found for the issue, treat that as a complete answer (nothing to merge). Do not prompt for a manual PR number; stop or continue to the next issue.
 7. **Record:** persist outcomes and continue.
 
 ## Quality Gates

--- a/.github/prompts/modules/continue-phase-2-workflow.md
+++ b/.github/prompts/modules/continue-phase-2-workflow.md
@@ -19,6 +19,10 @@ Limit policy:
 4. **Validate:** run required checks for changed areas before PR merge.
 5. **Review gate:** ensure PR reviewed and approved before merge.
 6. **Merge gate:** merge with `./scripts/prmerge <issue>` after CI pass.
+
+Merge rule:
+
+- If `prmerge` reports no PR found for the issue, treat that as a complete answer (nothing to merge). Do not prompt for a manual PR number; stop or continue to the next issue.
 7. **Record:** append notes/artifacts and continue to next issue.
 
 ## Quality Gates

--- a/docs/prmerge-command.md
+++ b/docs/prmerge-command.md
@@ -387,8 +387,11 @@ Failed checks:
 ```
 ❌ No PR found for Issue #24
 ℹ Attempting alternate search pattern...
-❌ Could not find PR. Please specify PR number manually:
-Enter PR number:
+If no PR exists for the issue, `prmerge` will now exit cleanly without prompting ("Nothing to merge").
+
+If you need to merge a PR with a non-standard title (so it isn't discoverable by issue number), you can override discovery:
+
+- Set `PRMERGE_PR_NUMBER=<pr>` and re-run `./scripts/prmerge <issue>`
 ```
 
 ### Branch Protection Block

--- a/scripts/prmerge
+++ b/scripts/prmerge
@@ -742,20 +742,36 @@ section "Step 1: Validate PR and CI Status"
 
 # Find PR number for this issue
 info "Finding PR for Issue #$ISSUE_NUMBER..."
-PR_NUMBER=$(gh pr list --search "issue #$ISSUE_NUMBER in:title" --state all --json number --jq '.[0].number' 2>/dev/null || echo "")
+PR_NUMBER=""
+
+# Allow explicit override (e.g., for unusual titles/search failures)
+if [ -n "${PRMERGE_PR_NUMBER:-}" ]; then
+    PR_NUMBER="$PRMERGE_PR_NUMBER"
+fi
 
 if [ -z "$PR_NUMBER" ]; then
-    error "No PR found for Issue #$ISSUE_NUMBER"
-    info "Attempting alternate search pattern..."
-    PR_NUMBER=$(gh pr list --search "$ISSUE_NUMBER" --state all --json number,title --jq ".[] | select(.title | contains(\"#$ISSUE_NUMBER\") or contains(\"Issue $ISSUE_NUMBER\")) | .number" | head -1)
-    
+    PR_NUMBER=$(gh pr list --search "issue #$ISSUE_NUMBER in:title" --state all --json number --jq '.[0].number' 2>/dev/null)
+    PR_LIST_EXIT=$?
+    if [ $PR_LIST_EXIT -ne 0 ]; then
+        error "Failed to search PRs via gh (exit=$PR_LIST_EXIT). Check auth/rate limits and retry."
+        exit 1
+    fi
+fi
+
+if [ -z "$PR_NUMBER" ]; then
+    info "No PR found by exact title pattern; attempting alternate search pattern..."
+    PR_NUMBER=$(gh pr list --search "$ISSUE_NUMBER" --state all --json number,title --jq ".[] | select(.title | contains(\"#$ISSUE_NUMBER\") or contains(\"Issue $ISSUE_NUMBER\")) | .number" | head -1 2>/dev/null)
+    PR_ALT_EXIT=$?
+    if [ $PR_ALT_EXIT -ne 0 ]; then
+        error "Failed to run alternate PR search via gh (exit=$PR_ALT_EXIT). Check auth/rate limits and retry."
+        exit 1
+    fi
+
     if [ -z "$PR_NUMBER" ]; then
-        error "Could not find PR. Please specify PR number manually:"
-        read -p "Enter PR number: " PR_NUMBER
-        if [ -z "$PR_NUMBER" ]; then
-            error "PR number required"
-            exit 1
-        fi
+        warning "No PR found for Issue #$ISSUE_NUMBER. Nothing to merge."
+        info "Create a PR titled like: 'issue #$ISSUE_NUMBER: <short description>' and re-run."
+        info "Optional override: set PRMERGE_PR_NUMBER=<pr> if you need to merge a PR with a non-standard title."
+        exit 0
     fi
 fi
 


### PR DESCRIPTION
# Summary
Remove the manual "Enter PR number" prompt from `scripts/prmerge`. If PR discovery succeeds but finds no PR, `prmerge` exits cleanly with a clear "Nothing to merge" message. If `gh` fails, it exits non-zero without prompting.

## Goal / Acceptance Criteria (required)
- [x] No manual PR-number prompt when no PR exists
- [x] Clean exit (no-op) when search succeeds but finds no PR
- [x] Non-zero exit when `gh` search fails (still no prompt)
- [x] Workflow/agent docs encode the same rule

## Issue / Tracking Link (required)
Fixes: #499

## Validation (required)
- `bash -n scripts/prmerge`
- Manual: `./scripts/prmerge 499` (before PR) exits 0 without prompting

## Automated checks
Evidence: GitHub Actions (if configured)

## Manual test evidence (required)
Evidence: Verified `./scripts/prmerge 499` returns `0` and does not prompt when no PR is present; override documented via `PRMERGE_PR_NUMBER`.