### PR TITLE
docs: close out split placeholder #477

### DIFF
--- a/docs/issues/issue-477-context.md
+++ b/docs/issues/issue-477-context.md
@@ -1,0 +1,39 @@
+# Issue 477 — Split Placeholder Closeout (Traceability)
+
+## Summary
+
+Issue #477 is part of the #435 split chain for the Context7 integration hardening track, but it contains only generic placeholder scope (“Create issue B for implementation slice 1 with focused validation”) and does not define any concrete backend changes.
+
+The underlying Context7 work is already present in this repository (see #425) and the planning/spec baseline already exists (see #437).
+
+This slice closes #477 by recording that it is non-actionable as written and pointing to the canonical spec/validation docs.
+
+## Links
+
+- Backend issue (this): https://github.com/blecx/AI-Agent-Framework/issues/477
+- Split chain parent: https://github.com/blecx/AI-Agent-Framework/issues/435
+- Upstream root context: https://github.com/blecx/AI-Agent-Framework/issues/425
+- Existing planning/spec baseline: https://github.com/blecx/AI-Agent-Framework/blob/main/docs/issues/issue-437-context.md
+- Context7 how-to (validation commands): https://github.com/blecx/AI-Agent-Framework/blob/main/docs/howto/context7-vscode-docker.md
+
+## Scope
+
+### In Scope
+
+- Record closeout traceability for a non-actionable split placeholder.
+
+### Out of Scope
+
+- Any Context7 implementation changes.
+- Any client repository changes.
+
+## Acceptance Criteria
+
+- [x] Scoped implementation is complete and validated (placeholder closeout recorded).
+- [x] Changes remain within one reviewable PR.
+- [x] No sensitive files committed (`projectDocs/`, `configs/llm.json`).
+
+## Validation
+
+- ✅ `ls -la docs/issues/issue-477-context.md`
+- ✅ `git status --short`


### PR DESCRIPTION
# Summary

Docs-only closeout for backend split placeholder #477: records that the issue contains no actionable requirements and points to the existing Context7 planning/spec baseline and validation docs.

## Goal / Acceptance Criteria (required)

- [x] Record traceability/closeout for non-actionable split placeholder #477.
- [x] Keep changes small and reviewable (single PR).
- [x] Avoid sensitive files (`projectDocs/`, `configs/llm.json`).

## Issue / Tracking Link (required)

- https://github.com/blecx/AI-Agent-Framework/issues/477

Fixes: #477

## Validation (required)

Evidence: ✅ `git diff --name-only origin/main...HEAD` → `docs/issues/issue-477-context.md`

## Automated checks

Evidence: ✅ Not applicable (docs-only change)

## Manual test evidence (required)

Evidence: ✅ Not applicable (docs-only change)