### PR TITLE
docs: close out split placeholder #478

### DIFF
--- a/docs/issues/issue-478-context.md
+++ b/docs/issues/issue-478-context.md
@@ -1,0 +1,22 @@
+# Issue #478 Context (Split Placeholder Closeout)
+
+## Summary
+Issue #478 is an auto-generated split placeholder from #435 (which itself was a split placeholder from #425). The body contains only generic instructions to “Create issue C” and does not define any implementation or documentation requirements beyond the already-tracked planning/spec alignment work.
+
+## Why this can be closed
+- #478 contains no actionable scope beyond “create a follow-up slice”.
+- The parent split chain (#425 → #435 → #478) was used to keep manual work under 20 minutes, and the planning/spec alignment request has already been captured elsewhere.
+- Closing #478 reduces tracker noise and keeps the repository aligned to real, actionable work.
+
+## Traceability
+- Parent issue: #435 (closed)
+- Root issue: #425
+- Planning/spec alignment reference: `docs/issues/issue-437-context.md`
+- Related closeouts in this chain:
+  - Issue #476 closeout (PR #537)
+  - Issue #477 closeout (PR #538)
+
+## Validation
+- Docs-only change.
+- No runtime behavior impacted.
+- No sensitive files touched (`projectDocs/`, `configs/llm.json`).


### PR DESCRIPTION
## Goal / Context
Close split placeholder issue #478 by recording non-actionable scope traceability in docs only.

## Acceptance Criteria
- [x] Added issue #478 traceability closeout document under docs/issues.
- [x] Kept change set to one small reviewable docs-only PR.
- [x] No sensitive files were committed.

## Validation Evidence
- [x] Verified file exists: ls -la docs/issues/issue-478-context.md
- [x] Verified clean intended diff scope via git status --short (only docs file for this PR)

## Repo Hygiene / Safety
- [x] No projectDocs files committed
- [x] No configs/llm.json committed
- [x] No unrelated code/test changes included

## Summary
This PR closes split placeholder #478 using the established traceability-closeout pattern. The issue text is generic/non-actionable, so this records context and links to canonical docs/work.

## Changes
- Added docs/issues/issue-478-context.md

Fixes #478