### PR TITLE
feat(mockups): generate images via OpenAI

### DIFF
--- a/agents/tooling/mockup_image_generation.py
+++ b/agents/tooling/mockup_image_generation.py
@@ -1,0 +1,79 @@
+"""Mockup image generation.
+
+Generates one or more UI mockup images using OpenAI Images and writes them into a
+deterministic local artifact directory under `.tmp/mockups/issue-<n>/`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Sequence
+
+from agents.tooling.mockup_artifacts import get_mockup_dir, write_mockup_index_html
+from agents.tooling.openai_images_client import (
+    OpenAIAPIKeyMissingError,
+    OpenAIImagesClient,
+    OpenAIImagesGenerateParams,
+)
+
+
+@dataclass(frozen=True)
+class MockupGenerationResult:
+    ok: bool
+    message: str
+    output_dir: Path
+    image_paths: Sequence[Path]
+    index_html_path: Optional[Path]
+
+
+def generate_issue_mockup_artifacts(
+    issue_number: int,
+    *,
+    prompt: str,
+    image_count: int = 1,
+    base_dir: Path | str = ".tmp/mockups",
+    api_key: str | None = None,
+    model: str = "gpt-image-1",
+    size: str = "1024x1024",
+    openai_client: OpenAIImagesClient | None = None,
+) -> MockupGenerationResult:
+    """Generate mockup images and write outputs under `.tmp/mockups/issue-<n>/`.
+
+    This function is designed as a single, workflow-callable entry point.
+    """
+    if image_count <= 0:
+        raise ValueError("image_count must be a positive integer")
+
+    output_dir = get_mockup_dir(issue_number, base_dir=base_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        client = openai_client or OpenAIImagesClient(api_key=api_key)
+    except OpenAIAPIKeyMissingError as exc:
+        return MockupGenerationResult(
+            ok=False,
+            message=str(exc),
+            output_dir=output_dir,
+            image_paths=(),
+            index_html_path=None,
+        )
+
+    params = OpenAIImagesGenerateParams(model=model, size=size)
+
+    image_paths: list[Path] = []
+    for idx in range(image_count):
+        png_bytes = client.generate_png_bytes(prompt, params=params)
+        out_path = output_dir / f"mockup-{idx + 1:03d}.png"
+        out_path.write_bytes(png_bytes)
+        image_paths.append(out_path)
+
+    index_html = write_mockup_index_html(output_dir)
+
+    return MockupGenerationResult(
+        ok=True,
+        message=f"Wrote {len(image_paths)} mockup image(s) to {output_dir}",
+        output_dir=output_dir,
+        image_paths=tuple(image_paths),
+        index_html_path=index_html,
+    )

--- a/agents/tooling/openai_images_client.py
+++ b/agents/tooling/openai_images_client.py
@@ -1,0 +1,106 @@
+"""OpenAI Images client wrapper.
+
+Minimal wrapper around the OpenAI Images API for generating UI mockup images.
+
+Notes:
+- Reads API key from `OPENAI_API_KEY` if not provided.
+- Does not persist secrets to disk.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+class OpenAIAPIKeyMissingError(RuntimeError):
+    """Raised when `OPENAI_API_KEY` is not configured."""
+
+
+@dataclass(frozen=True)
+class OpenAIImagesGenerateParams:
+    model: str = "gpt-image-1"
+    size: str = "1024x1024"
+    response_format: str = "b64_json"
+
+
+class OpenAIImagesClient:
+    """Small OpenAI Images client wrapper.
+
+    The wrapper is designed for easy unit testing by allowing dependency injection
+    of an already-constructed OpenAI client.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: Optional[str] = None,
+        openai_client: Any | None = None,
+    ):
+        resolved_key = api_key or os.getenv("OPENAI_API_KEY")
+        if not resolved_key and openai_client is None:
+            raise OpenAIAPIKeyMissingError(
+                "OPENAI_API_KEY is not set. Set OPENAI_API_KEY to enable image generation."
+            )
+
+        if openai_client is not None:
+            self._client = openai_client
+            return
+
+        # Import lazily to keep this module pure-Python for environments that
+        # don't need Images (and to make unit tests easier to isolate).
+        from openai import OpenAI  # type: ignore
+
+        self._client = OpenAI(api_key=resolved_key)
+
+    def generate_png_bytes(
+        self,
+        prompt: str,
+        *,
+        params: OpenAIImagesGenerateParams | None = None,
+    ) -> bytes:
+        """Generate a single image and return PNG bytes."""
+        if not prompt or not prompt.strip():
+            raise ValueError("prompt must be a non-empty string")
+
+        resolved = params or OpenAIImagesGenerateParams()
+
+        response = self._client.images.generate(
+            model=resolved.model,
+            prompt=prompt,
+            size=resolved.size,
+            response_format=resolved.response_format,
+        )
+
+        b64_json = _extract_first_b64_json(response)
+        try:
+            return base64.b64decode(b64_json)
+        except Exception as exc:  # pragma: no cover
+            raise RuntimeError("Failed to decode image base64 payload") from exc
+
+
+def _extract_first_b64_json(response: Any) -> str:
+    """Extract `data[0].b64_json` from OpenAI SDK or dict-like response."""
+    data = None
+    if hasattr(response, "data"):
+        data = getattr(response, "data")
+    elif isinstance(response, dict):
+        data = response.get("data")
+
+    if not data or not isinstance(data, list):
+        raise RuntimeError("OpenAI Images response missing 'data' list")
+
+    first = data[0]
+    if hasattr(first, "b64_json"):
+        b64_json = getattr(first, "b64_json")
+    elif isinstance(first, dict):
+        b64_json = first.get("b64_json")
+    else:
+        b64_json = None
+
+    if not b64_json or not isinstance(b64_json, str):
+        raise RuntimeError("OpenAI Images response missing 'b64_json' payload")
+
+    return b64_json

--- a/docs/howto/install-and-llm-setup.md
+++ b/docs/howto/install-and-llm-setup.md
@@ -188,6 +188,13 @@ Use GitHub Models endpoint with a GitHub token:
 }
 ```
 
+### OpenAI Images (Mockups)
+
+Some workflow steps can optionally generate UI mockup images using the OpenAI Images API (`gpt-image-1`).
+
+- Set `OPENAI_API_KEY` in your environment (never commit this).
+- Outputs are written under `.tmp/mockups/issue-<n>/` and include an `index.html` you can open directly.
+
 ### 3) Local models
 
 #### LM Studio

--- a/tests/unit/test_mockup_image_generation.py
+++ b/tests/unit/test_mockup_image_generation.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+import pytest
+
+from agents.tooling.mockup_image_generation import generate_issue_mockup_artifacts
+from agents.tooling.openai_images_client import OpenAIImagesGenerateParams
+
+
+class _FakeOpenAIImagesClient:
+    def __init__(self, payload: bytes):
+        self._payload = payload
+        self.calls = []
+
+    def generate_png_bytes(
+        self,
+        prompt: str,
+        *,
+        params: OpenAIImagesGenerateParams | None = None,
+    ) -> bytes:
+        self.calls.append({"prompt": prompt, "params": params})
+        return self._payload
+
+
+def test_generate_issue_mockup_artifacts_missing_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    result = generate_issue_mockup_artifacts(
+        481,
+        prompt="a mock UI",
+        base_dir=tmp_path,
+    )
+    assert result.ok is False
+    assert "OPENAI_API_KEY" in result.message
+
+
+def test_generate_issue_mockup_artifacts_writes_files(tmp_path: Path):
+    fake_png = b"\x89PNG\r\n\x1a\nFAKE"
+    fake_client = _FakeOpenAIImagesClient(fake_png)
+
+    result = generate_issue_mockup_artifacts(
+        481,
+        prompt="a mock UI",
+        image_count=2,
+        base_dir=tmp_path,
+        openai_client=fake_client,
+    )
+
+    out_dir = tmp_path / "issue-481"
+    assert result.ok is True
+    assert result.output_dir == out_dir
+    assert (out_dir / "mockup-001.png").exists()
+    assert (out_dir / "mockup-002.png").exists()
+    assert (out_dir / "index.html").exists()
+    assert len(result.image_paths) == 2
+    assert len(fake_client.calls) == 2


### PR DESCRIPTION
# Summary
Add a minimal OpenAI Images (gpt-image-1) integration that generates UI mockup images and writes deterministic local artifacts under `.tmp/mockups/issue-<n>/` (images + `index.html`).

## Goal / Acceptance Criteria (required)
- [x] Add a small image client wrapper (env-keyed, no secrets on disk)
- [x] Write artifacts under `.tmp/mockups/issue-<n>/` (images + `index.html`)
- [x] Provide a single workflow-callable entry point
- [x] Add unit tests + document `OPENAI_API_KEY` and output location

## Issue / Tracking Link (required)
- https://github.com/blecx/AI-Agent-Framework/issues/481

Fixes: #481

## Validation (required)
PYTHONPATH=apps/api .venv/bin/python -m pytest tests/unit -q
415 passed, 4 warnings in 14.90s

PYTHONPATH=apps/api .venv/bin/python -m pytest tests/unit -k mockup -q
7 passed, 408 deselected, 4 warnings in 3.59s

## Automated checks
- Not run here (relies on CI).

## Manual test evidence (required)
- Not run (requires `OPENAI_API_KEY`).
- To try locally: set `OPENAI_API_KEY`, then call `agents.tools.generate_mockup_artifacts` (or `agents.tooling.mockup_image_generation.generate_issue_mockup_artifacts`) and open `.tmp/mockups/issue-<n>/index.html`.
