### PR TITLE
feat(workflow): add Phase 2.6 mockups

### DIFF
--- a/docs/WORK-ISSUE-WORKFLOW.md
+++ b/docs/WORK-ISSUE-WORKFLOW.md
@@ -176,6 +176,14 @@ bash scripts/archive-goals.sh
 
 **Goal:** Understand issue and create implementation plan
 
+### Autonomous Subphases (2.5 → 2.6)
+
+When running via the autonomous agent (`scripts/work-issue.py`), Phase 2 includes two additional subphases for UI-impacting work:
+
+- **Phase 2.5 (UX gate):** consults the UX authority and may block or require changes.
+- **Phase 2.6 (Mockups + prototype):** generates UI mockup artifacts under `.tmp/mockups/issue-<n>/` (images + `index.html`) and persists designer outputs when available.
+   - If image generation is unavailable (e.g., missing `OPENAI_API_KEY`), the workflow continues but records a clear skip reason.
+
 **Steps:**
 
 1. **Read Full Issue**


### PR DESCRIPTION
# Summary
Insert a new autonomous workflow subphase (2.6) after the UX gate (2.5) to generate UI mockups/prototype artifacts under `.tmp/mockups/issue-<n>/` before coding begins.

## Goal / Acceptance Criteria (required)
- [x] Phase order is: UX gate (2.5) → mockups (2.6) → coding
- [x] If image generation is unavailable, workflow continues and records a clear skip reason
- [x] Evidence is persisted under `.tmp/mockups/issue-<n>/` for later review

## Issue / Tracking Link (required)
- https://github.com/blecx/AI-Agent-Framework/issues/483

Fixes: #483

## Validation (required)
PYTHONPATH=apps/api .venv/bin/python -m pytest tests/unit -k "workflow" -q
20 passed, 398 deselected, 4 warnings in 2.91s

## Automated checks
- Not run here (relies on CI).

## Manual test evidence (required)
- Not run end-to-end (requires running `scripts/work-issue.py`).
- Expected artifacts (when available): `.tmp/mockups/issue-<n>/` (png + `index.html` + designer markdown/YAML).
