### PR TITLE
feat(mockups): OpenAI Images wrapper helper

### DIFF
--- a/tests/unit/test_mockup_openai_images_client_wrapper.py
+++ b/tests/unit/test_mockup_openai_images_client_wrapper.py
@@ -1,0 +1,55 @@
+import base64
+
+from agents.tooling.openai_images_client import (
+    OpenAIImagesGenerateParams,
+    generate_mock_image,
+)
+
+
+class _FakeImages:
+    def __init__(self):
+        self.last_generate_kwargs = None
+
+    def generate(self, **kwargs):
+        self.last_generate_kwargs = kwargs
+        payload = base64.b64encode(b"fake-png-bytes").decode("utf-8")
+        return {"data": [{"b64_json": payload}]}
+
+
+class _FakeOpenAI:
+    def __init__(self):
+        self.images = _FakeImages()
+
+
+def test_generate_mock_image_missing_key_returns_failure(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    result = generate_mock_image("a prompt")
+
+    assert result.ok is False
+    assert result.message
+    assert "OPENAI_API_KEY" in result.message
+
+
+def test_generate_mock_image_uses_gpt_image_1_and_returns_payload():
+    fake = _FakeOpenAI()
+
+    result = generate_mock_image("a prompt", openai_client=fake)
+
+    assert result.ok is True
+    assert result.b64_json
+    assert result.png_bytes == b"fake-png-bytes"
+
+    # Verify parameters passed to OpenAI
+    assert fake.images.last_generate_kwargs["model"] == OpenAIImagesGenerateParams.model
+    assert fake.images.last_generate_kwargs["response_format"] == OpenAIImagesGenerateParams.response_format
+
+
+def test_generate_mock_image_allows_overriding_params():
+    fake = _FakeOpenAI()
+
+    params = OpenAIImagesGenerateParams(model="gpt-image-1", size="512x512")
+    result = generate_mock_image("a prompt", openai_client=fake, params=params)
+
+    assert result.ok is True
+    assert fake.images.last_generate_kwargs["size"] == "512x512"


### PR DESCRIPTION
## Goal / Context
- Implement a minimal OpenAI Images wrapper for `gpt-image-1` that is safe for unit tests and does not perform network calls in tests.
- Provide graceful, actionable behavior when `OPENAI_API_KEY` is missing.

## Acceptance Criteria
- [x] When `OPENAI_API_KEY` is missing, wrapper fails gracefully with clear message.
- [x] When key/client is present, wrapper can be invoked and returns image bytes from OpenAI response payload.
- [x] Unit tests mock OpenAI client calls (no network).

## Validation Evidence
- [x] Focused wrapper tests pass:
  - `./.venv/bin/python -m pytest tests/unit/test_mockup_openai_images_client_wrapper.py -q`
  - Result: `3 passed, 1 warning in 0.16s`
- [x] Issue-required command executed:
  - `./.venv/bin/python -m pytest tests/unit -k mockup -q`
  - Current baseline issue (pre-existing, unrelated): collection error in `tests/unit/test_audit_service.py` (`ModuleNotFoundError: No module named 'domain.audit'`).

## Repo Hygiene / Safety
- [x] No changes under `projectDocs/`.
- [x] No changes to `configs/llm.json`.
- [x] No submodule pointer updates staged.

Fixes: #486
Related repos/services impacted: blecx/AI-Agent-Framework (backend tooling only)

## How to review
1. Open `agents/tooling/openai_images_client.py` and verify missing-key behavior and simple wrapper API.
2. Verify response parsing path returns bytes from mocked image payload.
3. Open `tests/unit/test_mockup_openai_images_client_wrapper.py` and confirm tests are mocked/no-network.
4. Confirm PR scope is limited to wrapper + focused unit tests.

## Cross-repo / Downstream impact
- Backend repo: adds testable OpenAI Images wrapper helper.
- Client repo: none.
