### PR TITLE
chore: commit pending knowledge cache update

### DIFF
--- a/.issue-resolution-knowledge.json
+++ b/.issue-resolution-knowledge.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "last_updated": "2026-02-27T21:00:12.145967",
+  "last_updated": "2026-02-27T21:03:55.000000",
   "completed_issues": [
     {
       "issue_number": 25,
@@ -35,7 +35,7 @@
   "recommendations": {
     "last_selected": {
       "issue_number": 501,
-      "selected_at": "2026-02-27T21:00:12.145945",
+      "selected_at": "2026-02-27T21:03:55.000000",
       "reason": "Next in Unknown, all blockers resolved (verified via GitHub)",
       "github_state": "OPEN"
     }


### PR DESCRIPTION
## Goal / Context
- Persist pending local knowledge cache updates so the repository remains clean and traceability is maintained.
- Keep scope isolated to `.issue-resolution-knowledge.json` only.

## Acceptance Criteria
- [x] `.issue-resolution-knowledge.json` change is committed.
- [x] No unrelated files are included in the PR.
- [x] Required backend validation commands are run and documented.
- [x] PR is ready to merge once CI passes.

## Validation Evidence
- [x] Ran formatting/lint commands required by issue:
  - `./.venv/bin/python -m black apps/api/`
  - `./.venv/bin/python -m flake8 apps/api/`
  - Result: `77 files left unchanged` and no flake8 errors.
- [x] Ran full backend tests required by issue:
  - `./.venv/bin/python -m pytest`
  - Result: `857 passed, 7 skipped, 34 deselected, 21 warnings`.

## Repo Hygiene / Safety
- [x] No changes under `projectDocs/`.
- [x] No changes to `configs/llm.json`.
- [x] No submodule pointer updates staged.

Fixes: #501
Related repos/services impacted: blecx/AI-Agent-Framework (knowledge cache metadata only)

## How to review
1. Open `.issue-resolution-knowledge.json` and verify only timestamp/selection metadata updates.
2. Confirm no files outside `.issue-resolution-knowledge.json` are in the diff.
3. Confirm validation commands in this PR body match issue requirements.
4. Merge as a single small maintenance slice.

## Cross-repo / Downstream impact
- Backend repo: minor local knowledge-cache metadata persistence.
- Client repo: none.
