### PR TITLE
feat: Git MCP repo fundamentals server with safety guardrails (#566)

### DIFF
--- a/apps/mcp/repo_fundamentals/__init__.py
+++ b/apps/mcp/repo_fundamentals/__init__.py
@@ -1,0 +1,1 @@
+"""Repo fundamentals MCP servers and shared safety guards."""

--- a/apps/mcp/repo_fundamentals/git_server.py
+++ b/apps/mcp/repo_fundamentals/git_server.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import uvicorn
+from mcp.server.fastmcp import FastMCP
+
+from .git_service import GitService
+from .path_guard import PathGuardError
+
+
+def _load_service() -> GitService:
+    repo_root = Path(os.getenv("REPO_FUNDAMENTALS_REPO_ROOT", "/workspace")).resolve()
+    return GitService(repo_root=repo_root)
+
+
+service = _load_service()
+mcp = FastMCP("AI-Agent-Framework Git MCP", json_response=True)
+
+
+@mcp.tool()
+def git_safe_root() -> dict:
+    """Return effective repository root used by this server."""
+    return service.safe_root()
+
+
+@mcp.tool()
+def git_validate_path(path: str) -> dict:
+    """Validate repository-scoped path with denylist and escape guards."""
+    try:
+        return service.validate_path(path)
+    except PathGuardError as exc:
+        raise ValueError(str(exc)) from exc
+
+
+@mcp.tool()
+def git_status(path: str | None = None, short: bool = True) -> dict:
+    """Return git status for repository or one path."""
+    try:
+        return service.status(path=path, short=short)
+    except (PathGuardError, ValueError) as exc:
+        raise ValueError(str(exc)) from exc
+
+
+@mcp.tool()
+def git_log(max_count: int = 20, path: str | None = None) -> dict:
+    """Return recent commit summaries."""
+    try:
+        return service.log(max_count=max_count, path=path)
+    except (PathGuardError, ValueError) as exc:
+        raise ValueError(str(exc)) from exc
+
+
+@mcp.tool()
+def git_diff(path: str | None = None, staged: bool = False) -> dict:
+    """Return git diff output."""
+    try:
+        return service.diff(path=path, staged=staged)
+    except PathGuardError as exc:
+        raise ValueError(str(exc)) from exc
+
+
+@mcp.tool()
+def git_show(rev: str = "HEAD", path: str | None = None) -> dict:
+    """Return git show output for revision and optional path."""
+    try:
+        return service.show(rev=rev, path=path)
+    except (PathGuardError, ValueError) as exc:
+        raise ValueError(str(exc)) from exc
+
+
+@mcp.tool()
+def git_add(paths: list[str]) -> dict:
+    """Stage specific paths after safety validation."""
+    try:
+        return service.add(paths=paths)
+    except (PathGuardError, ValueError) as exc:
+        raise ValueError(str(exc)) from exc
+
+
+@mcp.tool()
+def git_commit(message: str) -> dict:
+    """Create a commit with the provided message."""
+    try:
+        return service.commit(message=message)
+    except ValueError as exc:
+        raise ValueError(str(exc)) from exc
+
+
+@mcp.tool()
+def git_reset_paths(paths: list[str]) -> dict:
+    """Unstage specific paths via git reset -- <paths>."""
+    try:
+        return service.reset_paths(paths=paths)
+    except (PathGuardError, ValueError) as exc:
+        raise ValueError(str(exc)) from exc
+
+
+def main() -> None:
+    host = os.getenv("GIT_MCP_HOST", "0.0.0.0")
+    port = int(os.getenv("GIT_MCP_PORT", "3012"))
+    app = mcp.streamable_http_app()
+    uvicorn.run(app, host=host, port=port)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/mcp/repo_fundamentals/git_service.py
+++ b/apps/mcp/repo_fundamentals/git_service.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .path_guard import PathGuardError, RepoPathGuard
+
+
+class GitServiceError(RuntimeError):
+    """Raised when a git command fails."""
+
+
+@dataclass
+class GitService:
+    repo_root: Path
+
+    def __post_init__(self) -> None:
+        self.repo_root = self.repo_root.resolve()
+        self.path_guard = RepoPathGuard(self.repo_root)
+
+    def _run_git(self, args: list[str]) -> str:
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=self.repo_root,
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode != 0:
+            stderr = proc.stderr.strip()
+            stdout = proc.stdout.strip()
+            message = stderr or stdout or f"git {' '.join(args)} failed"
+            raise GitServiceError(message)
+        return proc.stdout
+
+    def _validated_paths(self, paths: list[str]) -> list[str]:
+        validated: list[str] = []
+        for path in paths:
+            resolved = self.path_guard.resolve_relative_path(path, allow_nonexistent=True)
+            validated.append(str(resolved.relative_to(self.repo_root)))
+        return validated
+
+    def status(self, path: str | None = None, short: bool = True) -> dict[str, Any]:
+        args = ["status"]
+        if short:
+            args.append("--short")
+        if path:
+            args.extend(["--", *self._validated_paths([path])])
+        return {"output": self._run_git(args).strip()}
+
+    def log(self, max_count: int = 20, path: str | None = None) -> dict[str, Any]:
+        if max_count <= 0 or max_count > 200:
+            raise ValueError("max_count must be between 1 and 200")
+
+        args = ["log", f"--max-count={max_count}", "--pretty=format:%h %s"]
+        if path:
+            args.extend(["--", *self._validated_paths([path])])
+        return {"output": self._run_git(args).strip()}
+
+    def diff(self, path: str | None = None, staged: bool = False) -> dict[str, Any]:
+        args = ["diff"]
+        if staged:
+            args.append("--staged")
+        if path:
+            args.extend(["--", *self._validated_paths([path])])
+        return {"output": self._run_git(args)}
+
+    def add(self, paths: list[str]) -> dict[str, Any]:
+        if not paths:
+            raise ValueError("At least one path is required")
+        validated = self._validated_paths(paths)
+        self._run_git(["add", "--", *validated])
+        return {"added": validated}
+
+    def commit(self, message: str) -> dict[str, Any]:
+        cleaned = message.strip()
+        if not cleaned:
+            raise ValueError("Commit message is required")
+        output = self._run_git(["commit", "-m", cleaned])
+        return {"output": output.strip()}
+
+    def reset_paths(self, paths: list[str]) -> dict[str, Any]:
+        if not paths:
+            raise ValueError("At least one path is required")
+        validated = self._validated_paths(paths)
+        self._run_git(["reset", "--", *validated])
+        return {"reset": validated}
+
+    def show(self, rev: str = "HEAD", path: str | None = None) -> dict[str, Any]:
+        rev_clean = rev.strip()
+        if not rev_clean:
+            raise ValueError("rev is required")
+
+        args = ["show", rev_clean]
+        if path:
+            args.extend(["--", *self._validated_paths([path])])
+        return {"output": self._run_git(args)}
+
+    def safe_root(self) -> dict[str, Any]:
+        return {"repo_root": str(self.repo_root)}
+
+    def validate_path(self, path: str) -> dict[str, Any]:
+        resolved = self.path_guard.resolve_relative_path(path, allow_nonexistent=True)
+        return {
+            "path": path,
+            "resolved": str(resolved),
+            "relative": str(resolved.relative_to(self.repo_root)),
+        }

--- a/apps/mcp/repo_fundamentals/path_guard.py
+++ b/apps/mcp/repo_fundamentals/path_guard.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class PathGuardError(ValueError):
+    """Raised when a path violates repository safety constraints."""
+
+
+@dataclass(frozen=True)
+class RepoPathGuard:
+    repo_root: Path
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "repo_root", self.repo_root.resolve())
+
+    def resolve_relative_path(self, relative_path: str, *, allow_nonexistent: bool = True) -> Path:
+        candidate = Path(relative_path)
+
+        if candidate.is_absolute():
+            raise PathGuardError("Absolute paths are not allowed")
+
+        if any(part == ".." for part in candidate.parts):
+            raise PathGuardError("Path traversal is not allowed")
+
+        joined = self.repo_root / candidate
+        resolved = joined.resolve(strict=False)
+
+        try:
+            relative = resolved.relative_to(self.repo_root)
+        except ValueError as exc:
+            raise PathGuardError("Path escapes repository root") from exc
+
+        relative_text = relative.as_posix()
+        if relative_text == "projectDocs" or relative_text.startswith("projectDocs/"):
+            raise PathGuardError("Access to projectDocs is forbidden")
+
+        if relative_text == "configs/llm.json":
+            raise PathGuardError("Access to configs/llm.json is forbidden")
+
+        if not allow_nonexistent and not resolved.exists():
+            raise PathGuardError(f"Path not found: {relative_text}")
+
+        return resolved

--- a/docker/mcp-repo-fundamentals-git/Dockerfile
+++ b/docker/mcp-repo-fundamentals-git/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    GIT_MCP_PORT=3012 \
+    REPO_FUNDAMENTALS_REPO_ROOT=/workspace
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+RUN pip install --no-cache-dir \
+    mcp==1.12.4 \
+    uvicorn[standard]==0.27.0
+
+EXPOSE 3012
+
+CMD ["python", "-m", "apps.mcp.repo_fundamentals.git_server"]

--- a/tests/unit/test_mcp_repo_fundamentals_git.py
+++ b/tests/unit/test_mcp_repo_fundamentals_git.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from apps.mcp.repo_fundamentals.git_service import GitService
+from apps.mcp.repo_fundamentals.path_guard import PathGuardError, RepoPathGuard
+
+
+def test_path_guard_blocks_forbidden_targets(tmp_path: Path) -> None:
+    guard = RepoPathGuard(tmp_path)
+
+    with pytest.raises(PathGuardError):
+        guard.resolve_relative_path("projectDocs/test.md")
+
+    with pytest.raises(PathGuardError):
+        guard.resolve_relative_path("configs/llm.json")
+
+
+def test_path_guard_blocks_traversal(tmp_path: Path) -> None:
+    guard = RepoPathGuard(tmp_path)
+
+    with pytest.raises(PathGuardError):
+        guard.resolve_relative_path("../outside.txt")
+
+
+def test_path_guard_blocks_symlink_escape(tmp_path: Path) -> None:
+    outside = tmp_path.parent / "outside"
+    outside.mkdir(parents=True, exist_ok=True)
+    (outside / "secret.txt").write_text("x", encoding="utf-8")
+
+    link = tmp_path / "linked"
+    link.symlink_to(outside, target_is_directory=True)
+
+    guard = RepoPathGuard(tmp_path)
+    with pytest.raises(PathGuardError):
+        guard.resolve_relative_path("linked/secret.txt")
+
+
+def test_git_service_validated_paths_block_forbidden(tmp_path: Path) -> None:
+    service = GitService(repo_root=tmp_path)
+    with pytest.raises(PathGuardError):
+        service._validated_paths(["projectDocs/a.md"])
+
+
+def test_git_service_add_uses_validated_relative_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    file_path = tmp_path / "README.md"
+    file_path.write_text("ok", encoding="utf-8")
+
+    service = GitService(repo_root=tmp_path)
+
+    captured: dict[str, list[str]] = {}
+
+    def fake_run(args: list[str]) -> str:
+        captured["args"] = args
+        return ""
+
+    monkeypatch.setattr(service, "_run_git", fake_run)
+    result = service.add(paths=["README.md"])
+
+    assert result["added"] == ["README.md"]
+    assert captured["args"] == ["add", "--", "README.md"]


### PR DESCRIPTION
# Summary

Adds the first repo-fundamentals MCP slice: a Git Streamable HTTP server (`/mcp`) with safe read/write operations and strict repository path guardrails.

## Goal / Acceptance Criteria (required)

- [x] Git MCP server starts with configurable host/port and Streamable HTTP `/mcp` transport.
- [x] Read + write git operations are exposed with repo-root constrained execution.
- [x] Guardrails block path traversal, `projectDocs/`, `configs/llm.json`, and symlink/root escape.
- [x] Focused unit tests cover guardrail and command-path behavior.

## Issue / Tracking Link (required)

Fixes: #566

## Validation (required)

Implemented in:
- `apps/mcp/repo_fundamentals/path_guard.py`
- `apps/mcp/repo_fundamentals/git_service.py`
- `apps/mcp/repo_fundamentals/git_server.py`
- `docker/mcp-repo-fundamentals-git/Dockerfile`
- `tests/unit/test_mcp_repo_fundamentals_git.py`

## Automated checks

Evidence (inline): ✅ `./.venv/bin/python -m pytest tests/unit/test_mcp_repo_fundamentals_git.py -q` — PASS (`5 passed`).

## Manual test evidence (required)

Evidence (inline): ✅ static path-guard behavior validated via unit tests for traversal, symlink escape, forbidden targets, and safe staged-path argument building.

## Goal / Context

- Links: Fixes #566
- Related client repo (if relevant): N/A
- Scope (what’s included / excluded): includes Git MCP server + guardrails + tests + Dockerfile; excludes compose/systemd/VS Code wiring (handled in follow-up issue).

## Acceptance Criteria

- [x] AC1: Streamable HTTP Git MCP server is added.
- [x] AC2: Safe read/write git operations are implemented.
- [x] AC3: Required path safety constraints are enforced.

## Implementation Notes

- Key design choices: explicit `GitService` API and shared `RepoPathGuard` for deterministic safety checks.
- API changes (endpoints/contracts): no existing API endpoint changes.
- Cross-repo impact: none.

## Validation Evidence

Backend:
- [x] `./.venv/bin/python -m pytest tests/unit/test_mcp_repo_fundamentals_git.py -q` (PASS)

Frontend (if changed):
- [x] Not applicable (backend-only PR)

Docker (if changed):
- [x] Dockerfile added; runtime verification deferred to compose wiring issue (#569).

## Repo Hygiene / Safety

- [x] `projectDocs/` is NOT committed
- [x] `configs/llm.json` is NOT committed
- [x] No secrets in code/logs
