### PR TITLE
feat: Filesystem MCP repo fundamentals server (#568)

### DIFF
--- a/apps/mcp/repo_fundamentals/filesystem_server.py
+++ b/apps/mcp/repo_fundamentals/filesystem_server.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import uvicorn
+from mcp.server.fastmcp import FastMCP
+
+from .filesystem_service import FilesystemService
+from .path_guard import PathGuardError
+
+
+def _load_service() -> FilesystemService:
+    repo_root = Path(os.getenv("REPO_FUNDAMENTALS_REPO_ROOT", "/workspace")).resolve()
+    return FilesystemService(repo_root=repo_root)
+
+
+service = _load_service()
+mcp = FastMCP("AI-Agent-Framework Filesystem MCP", json_response=True)
+
+
+@mcp.tool()
+def filesystem_safe_root() -> dict:
+    """Return effective repository root used by this server."""
+    return {"repo_root": str(service.repo_root)}
+
+
+@mcp.tool()
+def filesystem_list_dir(path: str = ".") -> dict:
+    """List one directory under repository-safe scope."""
+    try:
+        return service.list_dir(path=path)
+    except (PathGuardError, ValueError) as exc:
+        raise ValueError(str(exc)) from exc
+
+
+@mcp.tool()
+def filesystem_read_text(path: str) -> dict:
+    """Read UTF-8 text file content."""
+    try:
+        return service.read_text(path=path)
+    except (PathGuardError, ValueError) as exc:
+        raise ValueError(str(exc)) from exc
+
+
+@mcp.tool()
+def filesystem_write_text(path: str, content: str, create_parent: bool = True) -> dict:
+    """Write UTF-8 text file content."""
+    try:
+        return service.write_text(path=path, content=content, create_parent=create_parent)
+    except (PathGuardError, ValueError) as exc:
+        raise ValueError(str(exc)) from exc
+
+
+@mcp.tool()
+def filesystem_make_dir(path: str, parents: bool = True) -> dict:
+    """Create directory in safe repository scope."""
+    try:
+        return service.make_dir(path=path, parents=parents)
+    except (PathGuardError, ValueError) as exc:
+        raise ValueError(str(exc)) from exc
+
+
+@mcp.tool()
+def filesystem_delete_path(path: str, recursive: bool = False) -> dict:
+    """Delete file or directory (requires recursive for directories)."""
+    try:
+        return service.delete_path(path=path, recursive=recursive)
+    except (PathGuardError, ValueError) as exc:
+        raise ValueError(str(exc)) from exc
+
+
+@mcp.tool()
+def filesystem_move_path(source: str, destination: str, overwrite: bool = False) -> dict:
+    """Move file/directory in safe repository scope."""
+    try:
+        return service.move_path(source=source, destination=destination, overwrite=overwrite)
+    except (PathGuardError, ValueError) as exc:
+        raise ValueError(str(exc)) from exc
+
+
+@mcp.tool()
+def filesystem_copy_path(source: str, destination: str, overwrite: bool = False) -> dict:
+    """Copy file/directory in safe repository scope."""
+    try:
+        return service.copy_path(source=source, destination=destination, overwrite=overwrite)
+    except (PathGuardError, ValueError) as exc:
+        raise ValueError(str(exc)) from exc
+
+
+def main() -> None:
+    host = os.getenv("FILESYSTEM_MCP_HOST", "0.0.0.0")
+    port = int(os.getenv("FILESYSTEM_MCP_PORT", "3014"))
+    app = mcp.streamable_http_app()
+    uvicorn.run(app, host=host, port=port)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/mcp/repo_fundamentals/filesystem_service.py
+++ b/apps/mcp/repo_fundamentals/filesystem_service.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .path_guard import RepoPathGuard
+
+
+@dataclass
+class FilesystemService:
+    repo_root: Path
+
+    def __post_init__(self) -> None:
+        self.repo_root = self.repo_root.resolve()
+        self.path_guard = RepoPathGuard(self.repo_root)
+
+    def _resolve_existing_file(self, path: str) -> Path:
+        resolved = self.path_guard.resolve_relative_path(path, allow_nonexistent=False)
+        if not resolved.is_file():
+            raise ValueError("path must resolve to a file")
+        return resolved
+
+    def _resolve_existing_path(self, path: str) -> Path:
+        return self.path_guard.resolve_relative_path(path, allow_nonexistent=False)
+
+    def _resolve_writable_path(self, path: str) -> Path:
+        resolved = self.path_guard.resolve_relative_path(path, allow_nonexistent=True)
+        parent = resolved.parent
+        parent.relative_to(self.repo_root)
+        return resolved
+
+    def list_dir(self, path: str = ".") -> dict[str, Any]:
+        resolved = self._resolve_existing_path(path)
+        if not resolved.is_dir():
+            raise ValueError("path must resolve to a directory")
+
+        children = sorted(resolved.iterdir(), key=lambda value: value.name)
+        entries = [
+            str(child.relative_to(self.repo_root)) + ("/" if child.is_dir() else "")
+            for child in children
+        ]
+        return {"path": str(resolved.relative_to(self.repo_root)), "entries": entries}
+
+    def read_text(self, path: str) -> dict[str, Any]:
+        resolved = self._resolve_existing_file(path)
+        content = resolved.read_text(encoding="utf-8")
+        return {
+            "path": str(resolved.relative_to(self.repo_root)),
+            "content": content,
+        }
+
+    def write_text(self, path: str, content: str, create_parent: bool = True) -> dict[str, Any]:
+        resolved = self._resolve_writable_path(path)
+        if create_parent:
+            resolved.parent.mkdir(parents=True, exist_ok=True)
+        elif not resolved.parent.exists():
+            raise ValueError("parent directory does not exist")
+
+        resolved.write_text(content, encoding="utf-8")
+        return {
+            "path": str(resolved.relative_to(self.repo_root)),
+            "bytes_written": len(content.encode("utf-8")),
+        }
+
+    def make_dir(self, path: str, parents: bool = True) -> dict[str, Any]:
+        resolved = self._resolve_writable_path(path)
+        resolved.mkdir(parents=parents, exist_ok=True)
+        return {"path": str(resolved.relative_to(self.repo_root))}
+
+    def delete_path(self, path: str, recursive: bool = False) -> dict[str, Any]:
+        resolved = self._resolve_existing_path(path)
+        relative = str(resolved.relative_to(self.repo_root))
+
+        if resolved.is_dir():
+            if not recursive:
+                raise ValueError("directory delete requires recursive=True")
+            shutil.rmtree(resolved)
+        else:
+            resolved.unlink()
+        return {"deleted": relative}
+
+    def move_path(self, source: str, destination: str, overwrite: bool = False) -> dict[str, Any]:
+        src = self._resolve_existing_path(source)
+        dst = self._resolve_writable_path(destination)
+        src_relative = str(src.relative_to(self.repo_root))
+        dst_relative = str(dst.relative_to(self.repo_root))
+
+        if dst.exists():
+            if not overwrite:
+                raise ValueError("destination already exists")
+            if dst.is_dir() and not src.is_dir():
+                raise ValueError("destination directory cannot overwrite file target")
+            if dst.is_dir():
+                shutil.rmtree(dst)
+            else:
+                dst.unlink()
+
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        src.rename(dst)
+        return {"moved_from": src_relative, "moved_to": dst_relative}
+
+    def copy_path(self, source: str, destination: str, overwrite: bool = False) -> dict[str, Any]:
+        src = self._resolve_existing_path(source)
+        dst = self._resolve_writable_path(destination)
+        src_relative = str(src.relative_to(self.repo_root))
+        dst_relative = str(dst.relative_to(self.repo_root))
+
+        if dst.exists():
+            if not overwrite:
+                raise ValueError("destination already exists")
+            if dst.is_dir():
+                shutil.rmtree(dst)
+            else:
+                dst.unlink()
+
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        if src.is_dir():
+            shutil.copytree(src, dst)
+        else:
+            shutil.copy2(src, dst)
+        return {"copied_from": src_relative, "copied_to": dst_relative}

--- a/docker/mcp-repo-fundamentals-filesystem/Dockerfile
+++ b/docker/mcp-repo-fundamentals-filesystem/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    FILESYSTEM_MCP_PORT=3014 \
+    REPO_FUNDAMENTALS_REPO_ROOT=/workspace
+
+WORKDIR /workspace
+
+RUN pip install --no-cache-dir \
+    mcp==1.12.4 \
+    uvicorn[standard]==0.27.0
+
+EXPOSE 3014
+
+CMD ["python", "-m", "apps.mcp.repo_fundamentals.filesystem_server"]

--- a/tests/unit/test_mcp_repo_fundamentals_filesystem.py
+++ b/tests/unit/test_mcp_repo_fundamentals_filesystem.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from apps.mcp.repo_fundamentals.filesystem_service import FilesystemService
+from apps.mcp.repo_fundamentals.path_guard import PathGuardError
+
+
+def test_write_read_and_list_dir(tmp_path: Path) -> None:
+    service = FilesystemService(repo_root=tmp_path)
+
+    write_result = service.write_text("src/test.txt", "hello")
+    assert write_result["path"] == "src/test.txt"
+
+    read_result = service.read_text("src/test.txt")
+    assert read_result["content"] == "hello"
+
+    list_result = service.list_dir("src")
+    assert "src/test.txt" in list_result["entries"]
+
+
+def test_move_and_copy_path(tmp_path: Path) -> None:
+    service = FilesystemService(repo_root=tmp_path)
+    service.write_text("a.txt", "a")
+
+    move_result = service.move_path("a.txt", "nested/b.txt")
+    assert move_result["moved_to"] == "nested/b.txt"
+
+    copy_result = service.copy_path("nested/b.txt", "nested/c.txt")
+    assert copy_result["copied_to"] == "nested/c.txt"
+
+    assert (tmp_path / "nested" / "b.txt").exists()
+    assert (tmp_path / "nested" / "c.txt").exists()
+
+
+def test_delete_dir_requires_recursive(tmp_path: Path) -> None:
+    service = FilesystemService(repo_root=tmp_path)
+    service.write_text("dir/file.txt", "x")
+
+    with pytest.raises(ValueError):
+        service.delete_path("dir", recursive=False)
+
+    service.delete_path("dir", recursive=True)
+    assert not (tmp_path / "dir").exists()
+
+
+def test_blocks_forbidden_project_docs(tmp_path: Path) -> None:
+    service = FilesystemService(repo_root=tmp_path)
+    with pytest.raises(PathGuardError):
+        service.write_text("projectDocs/secret.md", "x")
+
+
+def test_blocks_forbidden_llm_config(tmp_path: Path) -> None:
+    service = FilesystemService(repo_root=tmp_path)
+    with pytest.raises(PathGuardError):
+        service.write_text("configs/llm.json", "{}")
+
+
+def test_blocks_traversal(tmp_path: Path) -> None:
+    service = FilesystemService(repo_root=tmp_path)
+    with pytest.raises(PathGuardError):
+        service.read_text("../outside.txt")


### PR DESCRIPTION
# Summary

Adds the Filesystem repo-fundamentals MCP server with full file operations (including delete/move/copy) under strict repository safety constraints.

## Goal / Acceptance Criteria (required)

- [x] Filesystem MCP server starts with Streamable HTTP `/mcp` and configurable host/port.
- [x] Server supports read/write/delete/move/copy/list operations.
- [x] `projectDocs/`, `configs/llm.json`, traversal, and root/symlink escapes are blocked.
- [x] Focused unit tests validate allowed behavior and denial paths.

## Issue / Tracking Link (required)

Fixes: #568

## Validation (required)

Implemented in:
- `apps/mcp/repo_fundamentals/filesystem_service.py`
- `apps/mcp/repo_fundamentals/filesystem_server.py`
- `docker/mcp-repo-fundamentals-filesystem/Dockerfile`
- `tests/unit/test_mcp_repo_fundamentals_filesystem.py`

## Automated checks

Evidence (inline): ✅ `./.venv/bin/python -m pytest tests/unit/test_mcp_repo_fundamentals_filesystem.py -q` — PASS (`6 passed`).

## Manual test evidence (required)

Evidence (inline): ✅ unit tests verify write/read/list, move/copy, recursive delete behavior, and guardrail rejection of forbidden/traversal targets.

## Goal / Context

- Links: Fixes #568
- Related client repo (if relevant): N/A
- Scope (what’s included / excluded): includes Filesystem MCP service/server + Dockerfile + tests; excludes compose/systemd/VS Code wiring.

## Acceptance Criteria

- [x] AC1: Filesystem MCP transport and tool surface are implemented.
- [x] AC2: Forbidden targets and escape attempts are blocked.
- [x] AC3: Unit tests cover full-op and denied-op behavior.

## Implementation Notes

- Key design choices: shared `RepoPathGuard` for all filesystem operations and explicit, deterministic service methods.
- API changes (endpoints/contracts): no existing API endpoint changes.
- Cross-repo impact: none.

## Validation Evidence

Backend:
- [x] `./.venv/bin/python -m pytest tests/unit/test_mcp_repo_fundamentals_filesystem.py -q` (PASS)

Frontend (if changed):
- [x] Not applicable (backend-only PR)

Docker (if changed):
- [x] Dockerfile added for compose wiring in issue #569.

## Repo Hygiene / Safety

- [x] `projectDocs/` is NOT committed
- [x] `configs/llm.json` is NOT committed
- [x] No secrets in code/logs
