### PR TITLE
feat: wire repo-fundamentals MCP servers into compose, VS Code, and ops checks (#569)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -134,6 +134,15 @@
       },
       "bashGateway": {
         "url": "http://127.0.0.1:3011/mcp"
+      },
+      "git": {
+        "url": "http://127.0.0.1:3012/mcp"
+      },
+      "search": {
+        "url": "http://127.0.0.1:3013/mcp"
+      },
+      "filesystem": {
+        "url": "http://127.0.0.1:3014/mcp"
       }
     }
   },

--- a/apps/mcp/repo_fundamentals/filesystem_server.py
+++ b/apps/mcp/repo_fundamentals/filesystem_server.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import os
 from pathlib import Path
 

--- a/apps/mcp/repo_fundamentals/git_server.py
+++ b/apps/mcp/repo_fundamentals/git_server.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import os
 from pathlib import Path
 

--- a/apps/mcp/repo_fundamentals/search_server.py
+++ b/apps/mcp/repo_fundamentals/search_server.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import os
 import re
 from pathlib import Path

--- a/docker-compose.repo-fundamentals-mcp.yml
+++ b/docker-compose.repo-fundamentals-mcp.yml
@@ -1,0 +1,47 @@
+name: repo-fundamentals-mcp
+
+services:
+  git-mcp:
+    build:
+      context: .
+      dockerfile: docker/mcp-repo-fundamentals-git/Dockerfile
+    container_name: repo-fundamentals-git-mcp
+    restart: unless-stopped
+    environment:
+      - GIT_MCP_PORT=3012
+      - GIT_MCP_HOST=0.0.0.0
+      - REPO_FUNDAMENTALS_REPO_ROOT=/workspace
+    ports:
+      - "127.0.0.1:3012:3012"
+    volumes:
+      - ./:/workspace
+
+  search-mcp:
+    build:
+      context: .
+      dockerfile: docker/mcp-repo-fundamentals-search/Dockerfile
+    container_name: repo-fundamentals-search-mcp
+    restart: unless-stopped
+    environment:
+      - SEARCH_MCP_PORT=3013
+      - SEARCH_MCP_HOST=0.0.0.0
+      - REPO_FUNDAMENTALS_REPO_ROOT=/workspace
+    ports:
+      - "127.0.0.1:3013:3013"
+    volumes:
+      - ./:/workspace
+
+  filesystem-mcp:
+    build:
+      context: .
+      dockerfile: docker/mcp-repo-fundamentals-filesystem/Dockerfile
+    container_name: repo-fundamentals-filesystem-mcp
+    restart: unless-stopped
+    environment:
+      - FILESYSTEM_MCP_PORT=3014
+      - FILESYSTEM_MCP_HOST=0.0.0.0
+      - REPO_FUNDAMENTALS_REPO_ROOT=/workspace
+    ports:
+      - "127.0.0.1:3014:3014"
+    volumes:
+      - ./:/workspace

--- a/docs/howto/mcp-repo-fundamentals.md
+++ b/docs/howto/mcp-repo-fundamentals.md
@@ -1,0 +1,51 @@
+# MCP Repo Fundamentals (Git + Search + Filesystem)
+
+This stack provides local/free MCP servers for repository fundamentals over Streamable HTTP:
+
+- Git MCP: `http://127.0.0.1:3012/mcp`
+- Search MCP: `http://127.0.0.1:3013/mcp`
+- Filesystem MCP: `http://127.0.0.1:3014/mcp`
+
+Safety constraints are enforced server-side for all path-based operations:
+
+- deny `projectDocs/`
+- deny `configs/llm.json`
+- deny path traversal (`..`)
+- deny repository-root escape (including symlink escape)
+
+## Start with Docker Compose
+
+```bash
+docker compose -f docker-compose.repo-fundamentals-mcp.yml up -d --build
+```
+
+## Endpoint reachability check
+
+```bash
+curl -sS -o /dev/null -w "%{http_code}\n" http://127.0.0.1:3012/mcp
+curl -sS -o /dev/null -w "%{http_code}\n" http://127.0.0.1:3013/mcp
+curl -sS -o /dev/null -w "%{http_code}\n" http://127.0.0.1:3014/mcp
+```
+
+Expected for plain curl: `406`.
+
+## Install at boot (systemd)
+
+```bash
+chmod +x scripts/install-repo-fundamentals-mcp-systemd.sh
+./scripts/install-repo-fundamentals-mcp-systemd.sh
+```
+
+## VS Code MCP settings
+
+Workspace settings wire these server entries:
+
+- `mcp.servers.git.url = http://127.0.0.1:3012/mcp`
+- `mcp.servers.search.url = http://127.0.0.1:3013/mcp`
+- `mcp.servers.filesystem.url = http://127.0.0.1:3014/mcp`
+
+## Full MCP smoke test
+
+```bash
+bash scripts/mcp_smoke_test.sh
+```

--- a/scripts/install-repo-fundamentals-mcp-systemd.sh
+++ b/scripts/install-repo-fundamentals-mcp-systemd.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="${ROOT_DIR}/docker-compose.repo-fundamentals-mcp.yml"
+PROJECT_NAME="repo-fundamentals-mcp"
+UNIT_NAME="repo-fundamentals-mcp.service"
+UNIT_PATH="/etc/systemd/system/${UNIT_NAME}"
+ENV_FILE="/etc/default/repo-fundamentals-mcp"
+DOCKER_BIN="$(command -v docker || true)"
+SYSTEMCTL_BIN="$(command -v systemctl || true)"
+SUDO_BIN="$(command -v sudo || true)"
+
+if [[ -z "${DOCKER_BIN}" ]]; then
+  echo "docker command not found. Install Docker first."
+  exit 1
+fi
+
+if [[ -z "${SYSTEMCTL_BIN}" ]]; then
+  echo "systemctl not found. This script requires systemd."
+  exit 1
+fi
+
+if [[ -z "${SUDO_BIN}" ]]; then
+  echo "sudo command not found. This script requires sudo for unit installation."
+  exit 1
+fi
+
+if [[ ! -d /run/systemd/system ]]; then
+  echo "systemd does not appear to be active on this host."
+  exit 1
+fi
+
+if [[ ! -f "${COMPOSE_FILE}" ]]; then
+  echo "Compose file not found: ${COMPOSE_FILE}"
+  exit 1
+fi
+
+if ! "${DOCKER_BIN}" compose version >/dev/null 2>&1; then
+  echo "docker compose plugin not found. Install Docker Compose v2 support."
+  exit 1
+fi
+
+if [[ ! -f "${ENV_FILE}" ]]; then
+  sudo tee "${ENV_FILE}" >/dev/null <<'EOF'
+# Optional overrides for repo-fundamentals MCP service
+# REPO_FUNDAMENTALS_REPO_ROOT=/workspace
+EOF
+  sudo chmod 0600 "${ENV_FILE}"
+  echo "Created ${ENV_FILE} template."
+fi
+
+sudo tee "${UNIT_PATH}" >/dev/null <<EOF
+[Unit]
+Description=Repo Fundamentals MCP Docker Service
+After=docker.service network-online.target
+Wants=network-online.target
+Requires=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+EnvironmentFile=-${ENV_FILE}
+WorkingDirectory=${ROOT_DIR}
+ExecStart=${DOCKER_BIN} compose --project-name ${PROJECT_NAME} -f ${COMPOSE_FILE} up -d --build --remove-orphans
+ExecStop=${DOCKER_BIN} compose --project-name ${PROJECT_NAME} -f ${COMPOSE_FILE} down --remove-orphans
+ExecReload=${DOCKER_BIN} compose --project-name ${PROJECT_NAME} -f ${COMPOSE_FILE} up -d --build --remove-orphans
+TimeoutStartSec=600
+TimeoutStopSec=120
+UMask=0077
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo chmod 0644 "${UNIT_PATH}"
+sudo systemctl daemon-reload
+sudo systemctl enable --now "${UNIT_NAME}"
+
+echo "Installed and started ${UNIT_NAME}."
+echo "Environment file: ${ENV_FILE}"
+echo "Check status with: sudo systemctl status ${UNIT_NAME}"
+echo "Enabled: $(sudo systemctl is-enabled "${UNIT_NAME}")"
+echo "Active: $(sudo systemctl is-active "${UNIT_NAME}")"

--- a/scripts/mcp_smoke_test.sh
+++ b/scripts/mcp_smoke_test.sh
@@ -48,11 +48,18 @@ echo "[smoke] MCP services smoke test"
 
 check_systemd "context7-mcp.service"
 check_systemd "bash-gateway-mcp.service"
+check_systemd "repo-fundamentals-mcp.service"
 
 check_compose_service "context7-mcp" "$ROOT_DIR/docker-compose.context7.yml" "context7"
 check_compose_service "ai-agent-framework" "$ROOT_DIR/docker-compose.mcp-bash-gateway.yml" "bash-gateway-mcp"
+check_compose_service "repo-fundamentals-mcp" "$ROOT_DIR/docker-compose.repo-fundamentals-mcp.yml" "git-mcp"
+check_compose_service "repo-fundamentals-mcp" "$ROOT_DIR/docker-compose.repo-fundamentals-mcp.yml" "search-mcp"
+check_compose_service "repo-fundamentals-mcp" "$ROOT_DIR/docker-compose.repo-fundamentals-mcp.yml" "filesystem-mcp"
 
 check_endpoint_406 "Context7 MCP" "http://127.0.0.1:3010/mcp"
 check_endpoint_406 "Bash Gateway MCP" "http://127.0.0.1:3011/mcp"
+check_endpoint_406 "Git MCP" "http://127.0.0.1:3012/mcp"
+check_endpoint_406 "Search MCP" "http://127.0.0.1:3013/mcp"
+check_endpoint_406 "Filesystem MCP" "http://127.0.0.1:3014/mcp"
 
 echo "[smoke] PASS"

--- a/tests/unit/test_check_context7_guardrails.py
+++ b/tests/unit/test_check_context7_guardrails.py
@@ -29,6 +29,18 @@ def test_context7_guardrails_pass_with_required_snippets(tmp_path: Path):
                             "headers": {
                                 "CONTEXT7_API_KEY": "${env:CONTEXT7_API_KEY}",
                             },
+                        },
+                        "bashGateway": {
+                            "url": "http://127.0.0.1:3011/mcp",
+                        },
+                        "git": {
+                            "url": "http://127.0.0.1:3012/mcp",
+                        },
+                        "search": {
+                            "url": "http://127.0.0.1:3013/mcp",
+                        },
+                        "filesystem": {
+                            "url": "http://127.0.0.1:3014/mcp",
                         }
                     }
                 }


### PR DESCRIPTION
# Summary

Wires the new repo-fundamentals MCP servers (Git/Search/Filesystem) into operations: Docker Compose stack, VS Code MCP settings, systemd startup installer, smoke test coverage, guardrail checks, and concise how-to docs.

## Goal / Acceptance Criteria (required)

- [x] Compose stack for Git/Search/Filesystem MCP servers added on localhost ports 3012/3013/3014.
- [x] VS Code workspace MCP settings include `git`, `search`, and `filesystem` server URLs at `/mcp`.
- [x] Systemd installer added for repo-fundamentals MCP stack startup.
- [x] Smoke test extended to service-state and `/mcp` HTTP 406 checks for all MCP services.
- [x] Guardrail checker enforces required MCP server entries and localhost URLs.

## Issue / Tracking Link (required)

Fixes: #569

## Validation (required)

Implemented in:
- `docker-compose.repo-fundamentals-mcp.yml`
- `.vscode/settings.json`
- `scripts/install-repo-fundamentals-mcp-systemd.sh`
- `scripts/mcp_smoke_test.sh`
- `scripts/check_context7_guardrails.py`
- `tests/unit/test_check_context7_guardrails.py`
- `docs/howto/mcp-repo-fundamentals.md`
- plus FastMCP startup compatibility fix in repo-fundamentals server modules.

## Automated checks

Evidence (inline): ✅ `./.venv/bin/python -m pytest tests/unit/test_mcp_repo_fundamentals_git.py tests/unit/test_mcp_repo_fundamentals_search.py tests/unit/test_mcp_repo_fundamentals_filesystem.py tests/unit/test_check_context7_guardrails.py -q` — PASS (`18 passed`).

Evidence (inline): ✅ `./.venv/bin/python scripts/check_context7_guardrails.py` — PASS.

## Manual test evidence (required)

Evidence (inline): ✅ `docker compose -f docker-compose.repo-fundamentals-mcp.yml up -d --build --remove-orphans` followed by endpoint probes returned `406` for `3012/3013/3014`.

Evidence (inline): ✅ `bash scripts/mcp_smoke_test.sh` — PASS (Context7 + Bash Gateway + Repo Fundamentals services and all `/mcp` 406 checks).

## Goal / Context

- Links: Fixes #569
- Related client repo (if relevant): N/A
- Scope (what’s included / excluded): includes MCP wiring/ops and docs; excludes additional product features.

## Acceptance Criteria

- [x] AC1: Compose + VS Code MCP wiring completed for ports 3012/3013/3014.
- [x] AC2: systemd + smoke test + guardrail checks updated.
- [x] AC3: Documentation added for run/install/validation.

## Implementation Notes

- Key design choices: mirrored existing Context7/Bash Gateway patterns for compose/systemd/smoke consistency.
- API changes (endpoints/contracts): no existing API endpoint changes.
- Cross-repo impact: none.

## Validation Evidence

Backend:
- [x] `./.venv/bin/python -m pytest tests/unit/test_mcp_repo_fundamentals_git.py tests/unit/test_mcp_repo_fundamentals_search.py tests/unit/test_mcp_repo_fundamentals_filesystem.py tests/unit/test_check_context7_guardrails.py -q` (PASS)
- [x] `./.venv/bin/python scripts/check_context7_guardrails.py` (PASS)

Frontend (if changed):
- [x] Not applicable (backend-only PR)

Docker (if changed):
- [x] `docker compose -f docker-compose.repo-fundamentals-mcp.yml up -d --build --remove-orphans` (PASS)
- [x] `bash scripts/mcp_smoke_test.sh` (PASS)

## Repo Hygiene / Safety

- [x] `projectDocs/` is NOT committed
- [x] `configs/llm.json` is NOT committed
- [x] No secrets in code/logs
