### PR TITLE
feat: add local repo-fundamentals and devops MCP toolbox

### DIFF
--- a/.github/prompts/agents/create-issue.md
+++ b/.github/prompts/agents/create-issue.md
@@ -28,6 +28,7 @@ Draft and create high-quality GitHub issues (template-compliant, testable, and t
 - Keep acceptance criteria testable (`- [ ]` checkboxes).
 - Include explicit scope boundaries and validation steps.
 - For external API/framework behavior, require Context7 docs-grounding notes in the issue body.
+- If Context7 is unavailable/offline, require local docs grounding via repository sources (`docs/`, `README.md`, `templates/`) and local MCP search evidence.
 - For internal architecture decisions, anchor requirements to repository conventions and local codebase evidence.
 - Never implement code in this mode.
 

--- a/.github/prompts/agents/resolve-issue-dev.md
+++ b/.github/prompts/agents/resolve-issue-dev.md
@@ -26,6 +26,7 @@ Implement one issue into a small, reviewable PR with DDD-compliant changes and l
 - Follow DDD boundaries and keep diffs focused.
 - Use `.tmp/` for PR body and temporary artifacts.
 - For external API/framework usage, verify behavior against Context7 docs and capture assumptions when docs are version-ambiguous.
+- If Context7 is unavailable/offline, continue with local MCP-first grounding (`git`, `search`, `filesystem`, `bashGateway`) and repository docs (`docs/`, `README.md`, `templates/`).
 - For internal architecture, prioritize repository conventions and local source-of-truth files.
 - If scope affects UI/UX/navigation/responsive behavior, consult `blecs-ux-authority` and block completion until `UX_DECISION: PASS`.
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -143,6 +143,12 @@
       },
       "filesystem": {
         "url": "http://127.0.0.1:3014/mcp"
+      },
+      "dockerCompose": {
+        "url": "http://127.0.0.1:3015/mcp"
+      },
+      "testRunner": {
+        "url": "http://127.0.0.1:3016/mcp"
       }
     }
   },

--- a/apps/mcp/devops/audit_store.py
+++ b/apps/mcp/devops/audit_store.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class AuditRecord:
+    run_id: str
+    tool: str
+    timestamp_utc: str
+    status: str
+    exit_code: int
+    duration_sec: float
+    cwd: str
+    command: list[str]
+    output: str
+
+
+class AuditStore:
+    def __init__(self, base_dir: Path):
+        self.base_dir = base_dir
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+    def save(self, record: AuditRecord) -> Path:
+        file_path = self.base_dir / f"{record.run_id}.json"
+        file_path.write_text(json.dumps(asdict(record), indent=2), encoding="utf-8")
+        return file_path
+
+    def get(self, run_id: str) -> dict[str, Any] | None:
+        file_path = self.base_dir / f"{run_id}.json"
+        if not file_path.exists():
+            return None
+        return json.loads(file_path.read_text(encoding="utf-8"))

--- a/apps/mcp/devops/docker_compose_server.py
+++ b/apps/mcp/devops/docker_compose_server.py
@@ -1,0 +1,111 @@
+import os
+from pathlib import Path
+
+import uvicorn
+from mcp.server.fastmcp import FastMCP
+
+from .docker_compose_service import DockerComposeService, DockerComposeServiceError
+
+
+DEFAULT_TARGETS = {
+    "main": "docker-compose.yml",
+    "context7": "docker-compose.context7.yml",
+    "bash_gateway": "docker-compose.mcp-bash-gateway.yml",
+    "repo_fundamentals": "docker-compose.repo-fundamentals-mcp.yml",
+    "devops_mcp": "docker-compose.mcp-devops.yml",
+}
+
+
+def _load_targets() -> dict[str, str]:
+    raw = os.getenv("DOCKER_COMPOSE_MCP_TARGETS")
+    if not raw:
+        return DEFAULT_TARGETS
+
+    targets: dict[str, str] = {}
+    for pair in raw.split(","):
+        item = pair.strip()
+        if not item:
+            continue
+        if "=" not in item:
+            raise ValueError(f"Invalid target mapping: {item}")
+        name, compose_file = item.split("=", 1)
+        targets[name.strip()] = compose_file.strip()
+    return targets
+
+
+def _load_service() -> DockerComposeService:
+    repo_root = Path(os.getenv("DOCKER_COMPOSE_MCP_REPO_ROOT", "/workspace")).resolve()
+    audit_dir = Path(os.getenv("DOCKER_COMPOSE_MCP_AUDIT_DIR", str(repo_root / ".tmp" / "mcp-docker-compose"))).resolve()
+    return DockerComposeService(repo_root=repo_root, compose_targets=_load_targets(), audit_dir=audit_dir)
+
+
+service = _load_service()
+mcp = FastMCP("AI-Agent-Framework Docker Compose MCP", json_response=True)
+
+
+@mcp.tool()
+def docker_compose_targets() -> dict:
+    """Return allowed compose targets and mapped compose files."""
+    return service.list_targets()
+
+
+@mcp.tool()
+def docker_compose_ps(target: str = "main") -> dict:
+    """Show compose service status for one allowed target."""
+    try:
+        return service.compose_ps(target=target)
+    except (DockerComposeServiceError, ValueError) as exc:
+        raise ValueError(str(exc)) from exc
+
+
+@mcp.tool()
+def docker_compose_up(target: str = "main", build: bool = False, detach: bool = True) -> dict:
+    """Run docker compose up for one allowed target."""
+    try:
+        return service.compose_up(target=target, build=build, detach=detach)
+    except (DockerComposeServiceError, ValueError) as exc:
+        raise ValueError(str(exc)) from exc
+
+
+@mcp.tool()
+def docker_compose_down(target: str = "main", remove_orphans: bool = True) -> dict:
+    """Run docker compose down for one allowed target."""
+    try:
+        return service.compose_down(target=target, remove_orphans=remove_orphans)
+    except (DockerComposeServiceError, ValueError) as exc:
+        raise ValueError(str(exc)) from exc
+
+
+@mcp.tool()
+def docker_compose_logs(target: str = "main", service_name: str | None = None, tail: int = 200) -> dict:
+    """Fetch compose logs for one allowed target and optional service."""
+    try:
+        return service.compose_logs(target=target, service=service_name, tail=tail)
+    except (DockerComposeServiceError, ValueError) as exc:
+        raise ValueError(str(exc)) from exc
+
+
+@mcp.tool()
+def docker_compose_health(target: str = "main") -> dict:
+    """Return normalized container state/health for one compose target."""
+    try:
+        return service.container_health(target=target)
+    except (DockerComposeServiceError, ValueError) as exc:
+        raise ValueError(str(exc)) from exc
+
+
+@mcp.tool()
+def docker_compose_run_log(run_id: str) -> dict | None:
+    """Return one audited run log by run ID."""
+    return service.get_run_log(run_id)
+
+
+def main() -> None:
+    host = os.getenv("DOCKER_COMPOSE_MCP_HOST", "0.0.0.0")
+    port = int(os.getenv("DOCKER_COMPOSE_MCP_PORT", "3015"))
+    app = mcp.streamable_http_app()
+    uvicorn.run(app, host=host, port=port)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/mcp/devops/docker_compose_service.py
+++ b/apps/mcp/devops/docker_compose_service.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .audit_store import AuditRecord, AuditStore
+
+
+class DockerComposeServiceError(RuntimeError):
+    """Raised when docker compose command fails."""
+
+
+@dataclass
+class DockerComposeService:
+    repo_root: Path
+    compose_targets: dict[str, str]
+    audit_dir: Path
+
+    def __post_init__(self) -> None:
+        self.repo_root = self.repo_root.resolve()
+        self.audit_store = AuditStore(self.audit_dir)
+
+    def _resolve_compose_file(self, target: str) -> str:
+        compose_file = self.compose_targets.get(target)
+        if not compose_file:
+            raise ValueError(f"Unknown compose target: {target}")
+
+        candidate = (self.repo_root / compose_file).resolve()
+        try:
+            candidate.relative_to(self.repo_root)
+        except ValueError as exc:
+            raise ValueError("Compose file escapes repository root") from exc
+
+        if not candidate.exists():
+            raise ValueError(f"Compose file not found: {compose_file}")
+
+        relative = candidate.relative_to(self.repo_root).as_posix()
+        if relative == "projectDocs" or relative.startswith("projectDocs/"):
+            raise ValueError("Compose files under projectDocs are forbidden")
+        if relative == "configs/llm.json":
+            raise ValueError("configs/llm.json is forbidden")
+
+        return relative
+
+    def _run(self, tool: str, command: list[str]) -> dict[str, Any]:
+        run_id = uuid.uuid4().hex
+        start = time.perf_counter()
+        started_at = datetime.now(timezone.utc).isoformat()
+
+        proc = subprocess.run(
+            command,
+            cwd=self.repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        output = "\n".join(chunk for chunk in (proc.stdout.strip(), proc.stderr.strip()) if chunk)
+        status = "ok" if proc.returncode == 0 else "error"
+        duration = time.perf_counter() - start
+
+        self.audit_store.save(
+            AuditRecord(
+                run_id=run_id,
+                tool=tool,
+                timestamp_utc=started_at,
+                status=status,
+                exit_code=proc.returncode,
+                duration_sec=duration,
+                cwd=str(self.repo_root),
+                command=command,
+                output=output,
+            )
+        )
+
+        if proc.returncode != 0:
+            raise DockerComposeServiceError(output or f"Command failed: {' '.join(command)}")
+
+        return {
+            "run_id": run_id,
+            "status": status,
+            "exit_code": proc.returncode,
+            "duration_sec": duration,
+            "output": output,
+        }
+
+    def list_targets(self) -> dict[str, Any]:
+        return {"targets": [{"name": key, "compose_file": value} for key, value in sorted(self.compose_targets.items())]}
+
+    def compose_ps(self, target: str) -> dict[str, Any]:
+        compose_file = self._resolve_compose_file(target)
+        return self._run(
+            tool="compose_ps",
+            command=["docker", "compose", "-f", compose_file, "ps", "--all"],
+        )
+
+    def compose_up(self, target: str, build: bool = False, detach: bool = True) -> dict[str, Any]:
+        compose_file = self._resolve_compose_file(target)
+        command = ["docker", "compose", "-f", compose_file, "up"]
+        if build:
+            command.append("--build")
+        if detach:
+            command.append("-d")
+        return self._run(tool="compose_up", command=command)
+
+    def compose_down(self, target: str, remove_orphans: bool = True) -> dict[str, Any]:
+        compose_file = self._resolve_compose_file(target)
+        command = ["docker", "compose", "-f", compose_file, "down"]
+        if remove_orphans:
+            command.append("--remove-orphans")
+        return self._run(tool="compose_down", command=command)
+
+    def compose_logs(self, target: str, service: str | None = None, tail: int = 200) -> dict[str, Any]:
+        if tail <= 0 or tail > 5000:
+            raise ValueError("tail must be between 1 and 5000")
+
+        compose_file = self._resolve_compose_file(target)
+        command = ["docker", "compose", "-f", compose_file, "logs", "--no-color", "--tail", str(tail)]
+        if service:
+            command.append(service)
+        return self._run(tool="compose_logs", command=command)
+
+    def container_health(self, target: str) -> dict[str, Any]:
+        compose_file = self._resolve_compose_file(target)
+        raw = self._run(
+            tool="container_health",
+            command=["docker", "compose", "-f", compose_file, "ps", "--format", "json"],
+        )
+
+        containers: list[dict[str, Any]] = []
+        for line in raw["output"].splitlines():
+            entry = line.strip()
+            if not entry:
+                continue
+            try:
+                data = json.loads(entry)
+            except json.JSONDecodeError:
+                continue
+            containers.append(
+                {
+                    "name": data.get("Name"),
+                    "service": data.get("Service"),
+                    "state": data.get("State"),
+                    "health": data.get("Health"),
+                    "status": data.get("Status"),
+                }
+            )
+
+        return {
+            "run_id": raw["run_id"],
+            "count": len(containers),
+            "containers": containers,
+        }
+
+    def get_run_log(self, run_id: str) -> dict[str, Any] | None:
+        return self.audit_store.get(run_id)

--- a/apps/mcp/devops/test_runner_server.py
+++ b/apps/mcp/devops/test_runner_server.py
@@ -1,0 +1,49 @@
+import os
+from pathlib import Path
+
+import uvicorn
+from mcp.server.fastmcp import FastMCP
+
+from .test_runner_service import TestRunnerService, TestRunnerServiceError
+
+
+def _load_service() -> TestRunnerService:
+    repo_root = Path(os.getenv("TEST_RUNNER_MCP_REPO_ROOT", "/workspace")).resolve()
+    audit_dir = Path(os.getenv("TEST_RUNNER_MCP_AUDIT_DIR", str(repo_root / ".tmp" / "mcp-test-runner"))).resolve()
+    return TestRunnerService(repo_root=repo_root, audit_dir=audit_dir)
+
+
+service = _load_service()
+mcp = FastMCP("AI-Agent-Framework Test Runner MCP", json_response=True)
+
+
+@mcp.tool()
+def test_runner_profiles() -> dict:
+    """Return deterministic test/lint/build profiles available for execution."""
+    return service.list_profiles()
+
+
+@mcp.tool()
+def test_runner_run(profile_name: str) -> dict:
+    """Execute one deterministic profile and return captured output."""
+    try:
+        return service.run_profile(profile_name=profile_name)
+    except (TestRunnerServiceError, ValueError) as exc:
+        raise ValueError(str(exc)) from exc
+
+
+@mcp.tool()
+def test_runner_run_log(run_id: str) -> dict | None:
+    """Return one audited run log by run ID."""
+    return service.get_run_log(run_id)
+
+
+def main() -> None:
+    host = os.getenv("TEST_RUNNER_MCP_HOST", "0.0.0.0")
+    port = int(os.getenv("TEST_RUNNER_MCP_PORT", "3016"))
+    app = mcp.streamable_http_app()
+    uvicorn.run(app, host=host, port=port)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/mcp/devops/test_runner_service.py
+++ b/apps/mcp/devops/test_runner_service.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .audit_store import AuditRecord, AuditStore
+
+
+class TestRunnerServiceError(RuntimeError):
+    """Raised when a test profile command fails."""
+
+
+@dataclass(frozen=True)
+class TestProfile:
+    name: str
+    cwd: str
+    command: list[str]
+    timeout_sec: int
+
+
+@dataclass
+class TestRunnerService:
+    repo_root: Path
+    audit_dir: Path
+
+    def __post_init__(self) -> None:
+        self.repo_root = self.repo_root.resolve()
+        self.audit_store = AuditStore(self.audit_dir)
+
+        python_bin = os.getenv("TEST_RUNNER_PYTHON", "python")
+        self.profiles: dict[str, TestProfile] = {
+            "backend.format_lint": TestProfile(
+                name="backend.format_lint",
+                cwd=".",
+                command=[
+                    "bash",
+                    "-lc",
+                    f"{python_bin} -m black apps/api/ && {python_bin} -m flake8 apps/api/",
+                ],
+                timeout_sec=900,
+            ),
+            "backend.tests": TestProfile(
+                name="backend.tests",
+                cwd=".",
+                command=[python_bin, "-m", "pytest", "tests/", "-v"],
+                timeout_sec=1800,
+            ),
+            "backend.tests_quick": TestProfile(
+                name="backend.tests_quick",
+                cwd=".",
+                command=[python_bin, "-m", "pytest", "tests/", "-q", "--tb=short"],
+                timeout_sec=1200,
+            ),
+            "frontend.lint": TestProfile(
+                name="frontend.lint",
+                cwd="_external/AI-Agent-Framework-Client/client",
+                command=["npm", "run", "lint"],
+                timeout_sec=1200,
+            ),
+            "frontend.build": TestProfile(
+                name="frontend.build",
+                cwd="_external/AI-Agent-Framework-Client/client",
+                command=["npm", "run", "build"],
+                timeout_sec=1200,
+            ),
+        }
+
+    def list_profiles(self) -> dict[str, Any]:
+        return {
+            "profiles": [
+                {
+                    "name": profile.name,
+                    "cwd": profile.cwd,
+                    "command": profile.command,
+                    "timeout_sec": profile.timeout_sec,
+                }
+                for profile in self.profiles.values()
+            ]
+        }
+
+    def run_profile(self, profile_name: str) -> dict[str, Any]:
+        profile = self.profiles.get(profile_name)
+        if not profile:
+            raise ValueError(f"Unknown profile: {profile_name}")
+
+        cwd = (self.repo_root / profile.cwd).resolve()
+        try:
+            cwd.relative_to(self.repo_root)
+        except ValueError as exc:
+            raise ValueError("Profile cwd escapes repository root") from exc
+
+        run_id = uuid.uuid4().hex
+        start = time.perf_counter()
+        started_at = datetime.now(timezone.utc).isoformat()
+
+        proc = subprocess.run(
+            profile.command,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=profile.timeout_sec,
+        )
+
+        output = "\n".join(chunk for chunk in (proc.stdout.strip(), proc.stderr.strip()) if chunk)
+        status = "ok" if proc.returncode == 0 else "error"
+        duration = time.perf_counter() - start
+
+        self.audit_store.save(
+            AuditRecord(
+                run_id=run_id,
+                tool=profile_name,
+                timestamp_utc=started_at,
+                status=status,
+                exit_code=proc.returncode,
+                duration_sec=duration,
+                cwd=str(cwd),
+                command=profile.command,
+                output=output,
+            )
+        )
+
+        result = {
+            "run_id": run_id,
+            "profile": profile_name,
+            "status": status,
+            "exit_code": proc.returncode,
+            "duration_sec": duration,
+            "output": output,
+        }
+
+        if proc.returncode != 0:
+            raise TestRunnerServiceError(output or f"Profile failed: {profile_name}")
+
+        return result
+
+    def get_run_log(self, run_id: str) -> dict[str, Any] | None:
+        return self.audit_store.get(run_id)

--- a/apps/mcp/repo_fundamentals/git_server.py
+++ b/apps/mcp/repo_fundamentals/git_server.py
@@ -69,6 +69,32 @@ def git_show(rev: str = "HEAD", path: str | None = None) -> dict:
 
 
 @mcp.tool()
+def git_branch_current() -> dict:
+    """Return current checked-out branch name."""
+    return service.branch_current()
+
+
+@mcp.tool()
+def git_branch_list(all_branches: bool = False) -> dict:
+    """Return local or all branch names."""
+    return service.branch_list(all_branches=all_branches)
+
+
+@mcp.tool()
+def git_blame(
+    path: str,
+    rev: str | None = None,
+    line_start: int | None = None,
+    line_end: int | None = None,
+) -> dict:
+    """Return git blame porcelain output for a validated path."""
+    try:
+        return service.blame(path=path, rev=rev, line_start=line_start, line_end=line_end)
+    except (PathGuardError, ValueError) as exc:
+        raise ValueError(str(exc)) from exc
+
+
+@mcp.tool()
 def git_add(paths: list[str]) -> dict:
     """Stage specific paths after safety validation."""
     try:

--- a/docker-compose.mcp-devops.yml
+++ b/docker-compose.mcp-devops.yml
@@ -1,0 +1,36 @@
+name: devops-mcp
+
+services:
+  docker-compose-mcp:
+    build:
+      context: .
+      dockerfile: docker/mcp-devops-docker-compose/Dockerfile
+    container_name: devops-docker-compose-mcp
+    restart: unless-stopped
+    environment:
+      - DOCKER_COMPOSE_MCP_PORT=3015
+      - DOCKER_COMPOSE_MCP_HOST=0.0.0.0
+      - DOCKER_COMPOSE_MCP_REPO_ROOT=/workspace
+      - DOCKER_COMPOSE_MCP_AUDIT_DIR=/workspace/.tmp/mcp-docker-compose
+    ports:
+      - "127.0.0.1:3015:3015"
+    volumes:
+      - ./:/workspace
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  test-runner-mcp:
+    build:
+      context: .
+      dockerfile: docker/mcp-devops-test-runner/Dockerfile
+    container_name: devops-test-runner-mcp
+    restart: unless-stopped
+    environment:
+      - TEST_RUNNER_MCP_PORT=3016
+      - TEST_RUNNER_MCP_HOST=0.0.0.0
+      - TEST_RUNNER_MCP_REPO_ROOT=/workspace
+      - TEST_RUNNER_MCP_AUDIT_DIR=/workspace/.tmp/mcp-test-runner
+      - TEST_RUNNER_PYTHON=python3
+    ports:
+      - "127.0.0.1:3016:3016"
+    volumes:
+      - ./:/workspace

--- a/docker/mcp-devops-docker-compose/Dockerfile
+++ b/docker/mcp-devops-docker-compose/Dockerfile
@@ -1,0 +1,17 @@
+FROM docker:27-cli
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    DOCKER_COMPOSE_MCP_PORT=3015 \
+    DOCKER_COMPOSE_MCP_REPO_ROOT=/workspace
+
+WORKDIR /workspace
+
+RUN apk add --no-cache python3 py3-pip && \
+    pip install --no-cache-dir --break-system-packages \
+      mcp==1.12.4 \
+      uvicorn[standard]==0.27.0
+
+EXPOSE 3015
+
+CMD ["python3", "-m", "apps.mcp.devops.docker_compose_server"]

--- a/docker/mcp-devops-test-runner/Dockerfile
+++ b/docker/mcp-devops-test-runner/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:20-bookworm-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    TEST_RUNNER_MCP_PORT=3016 \
+    TEST_RUNNER_MCP_REPO_ROOT=/workspace
+
+WORKDIR /workspace
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends python3 python3-pip && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install --no-cache-dir --break-system-packages \
+      mcp==1.12.4 \
+      uvicorn[standard]==0.27.0
+
+EXPOSE 3016
+
+CMD ["python3", "-m", "apps.mcp.devops.test_runner_server"]

--- a/docker/mcp-repo-fundamentals-search/Dockerfile
+++ b/docker/mcp-repo-fundamentals-search/Dockerfile
@@ -7,6 +7,10 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /workspace
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ripgrep && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN pip install --no-cache-dir \
     mcp==1.12.4 \
     uvicorn[standard]==0.27.0

--- a/docs/howto/context7-vscode-docker.md
+++ b/docs/howto/context7-vscode-docker.md
@@ -3,6 +3,20 @@
 This guide installs Context7 for VS Code, runs a local Context7 MCP endpoint in
 Docker, and enables host boot startup.
 
+## Offline-first note
+
+Context7 is best when online because it fetches external docs.
+
+For strict offline workflows, prefer local MCP tools:
+
+- `git` MCP (`status`, `diff`, `log`, `blame`, `branch`)
+- `search` MCP (ripgrep-based, scoped to repository)
+- `filesystem` MCP (scoped writes with deny rules)
+- `bashGateway` MCP (policy allowlisted scripts + audit logs)
+
+When offline and you need docs grounding, scope local search to repository docs
+(`docs/`, `README.md`, `templates/`) instead of external fetches.
+
 ## 1) Install VS Code Extension
 
 ```bash

--- a/docs/howto/mcp-devops.md
+++ b/docs/howto/mcp-devops.md
@@ -1,0 +1,63 @@
+# MCP DevOps (Docker/Compose + Test Runner)
+
+This stack provides local/free DevOps MCP servers over Streamable HTTP:
+
+- Docker/Compose MCP: `http://127.0.0.1:3015/mcp`
+- Test Runner MCP: `http://127.0.0.1:3016/mcp`
+
+Both services are localhost-bound and write audited execution logs under `.tmp/`.
+
+## Start with Docker Compose
+
+```bash
+docker compose -f docker-compose.mcp-devops.yml up -d --build
+```
+
+## Endpoint reachability check
+
+```bash
+curl -sS -o /dev/null -w "%{http_code}\n" http://127.0.0.1:3015/mcp
+curl -sS -o /dev/null -w "%{http_code}\n" http://127.0.0.1:3016/mcp
+```
+
+Expected for plain curl: `406`.
+
+## Docker/Compose MCP scope
+
+Only allowlisted compose targets are exposed (for example `docker-compose.yml`,
+`docker-compose.repo-fundamentals-mcp.yml`, `docker-compose.mcp-devops.yml`).
+The server rejects compose paths that escape the workspace or target protected
+paths.
+
+Audit logs:
+
+- `.tmp/mcp-docker-compose/<run_id>.json`
+
+## Test Runner MCP profiles
+
+Deterministic profiles mirror project tasks:
+
+- `backend.format_lint`
+- `backend.tests`
+- `backend.tests_quick`
+- `frontend.lint`
+- `frontend.build`
+
+Audit logs:
+
+- `.tmp/mcp-test-runner/<run_id>.json`
+
+## VS Code MCP settings
+
+Workspace settings include:
+
+- `mcp.servers.dockerCompose.url = http://127.0.0.1:3015/mcp`
+- `mcp.servers.testRunner.url = http://127.0.0.1:3016/mcp`
+
+## Smoke test
+
+Use the compose-based smoke test:
+
+```bash
+bash scripts/mcp_smoke_test_compose.sh
+```

--- a/docs/howto/mcp-repo-fundamentals.md
+++ b/docs/howto/mcp-repo-fundamentals.md
@@ -13,6 +13,19 @@ Safety constraints are enforced server-side for all path-based operations:
 - deny path traversal (`..`)
 - deny repository-root escape (including symlink escape)
 
+## Provided MCP tools
+
+- Git MCP: `status`, `diff`, `log`, `show`, `branch current`, `branch list`, `blame`, staged-path helpers
+- Search MCP: ripgrep-backed search/list (`rg`) with server-enforced exclusions
+- Filesystem MCP: scoped read/write/list/mkdir/delete/move/copy with deny rules
+
+The Search MCP always excludes:
+
+- `projectDocs/**`
+- `configs/llm.json`
+
+even when querying from scope `.`.
+
 ## Start with Docker Compose
 
 ```bash

--- a/scripts/check_context7_guardrails.py
+++ b/scripts/check_context7_guardrails.py
@@ -35,6 +35,8 @@ REQUIRED_MCP_SERVER_URLS = {
     "git": "http://127.0.0.1:3012/mcp",
     "search": "http://127.0.0.1:3013/mcp",
     "filesystem": "http://127.0.0.1:3014/mcp",
+    "dockerCompose": "http://127.0.0.1:3015/mcp",
+    "testRunner": "http://127.0.0.1:3016/mcp",
 }
 
 

--- a/scripts/mcp_smoke_test_compose.sh
+++ b/scripts/mcp_smoke_test_compose.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+ok() {
+  echo "[ok] $1"
+}
+
+fail() {
+  echo "[fail] $1" >&2
+  exit 1
+}
+
+check_compose_service() {
+  local project_name="$1"
+  local compose_file="$2"
+  local service="$3"
+
+  local status
+  status="$(docker compose --project-name "$project_name" -f "$compose_file" ps --status running --services 2>/dev/null | grep -E "^${service}$" || true)"
+  [[ "$status" == "$service" ]] || fail "$service not running in $compose_file"
+  ok "$service running in compose project $project_name"
+}
+
+check_endpoint_406() {
+  local name="$1"
+  local url="$2"
+  local code
+  code="$(curl -sS -o /dev/null -w "%{http_code}" "$url" || true)"
+  [[ "$code" == "406" ]] || fail "$name endpoint expected HTTP 406, got $code"
+  ok "$name endpoint reachable ($code)"
+}
+
+echo "[smoke] MCP compose smoke test"
+
+check_compose_service "context7-mcp" "$ROOT_DIR/docker-compose.context7.yml" "context7"
+check_compose_service "ai-agent-framework" "$ROOT_DIR/docker-compose.mcp-bash-gateway.yml" "bash-gateway-mcp"
+check_compose_service "repo-fundamentals-mcp" "$ROOT_DIR/docker-compose.repo-fundamentals-mcp.yml" "git-mcp"
+check_compose_service "repo-fundamentals-mcp" "$ROOT_DIR/docker-compose.repo-fundamentals-mcp.yml" "search-mcp"
+check_compose_service "repo-fundamentals-mcp" "$ROOT_DIR/docker-compose.repo-fundamentals-mcp.yml" "filesystem-mcp"
+check_compose_service "devops-mcp" "$ROOT_DIR/docker-compose.mcp-devops.yml" "docker-compose-mcp"
+check_compose_service "devops-mcp" "$ROOT_DIR/docker-compose.mcp-devops.yml" "test-runner-mcp"
+
+check_endpoint_406 "Context7 MCP" "http://127.0.0.1:3010/mcp"
+check_endpoint_406 "Bash Gateway MCP" "http://127.0.0.1:3011/mcp"
+check_endpoint_406 "Git MCP" "http://127.0.0.1:3012/mcp"
+check_endpoint_406 "Search MCP" "http://127.0.0.1:3013/mcp"
+check_endpoint_406 "Filesystem MCP" "http://127.0.0.1:3014/mcp"
+check_endpoint_406 "Docker Compose MCP" "http://127.0.0.1:3015/mcp"
+check_endpoint_406 "Test Runner MCP" "http://127.0.0.1:3016/mcp"
+
+echo "[smoke] PASS"

--- a/tests/unit/test_check_context7_guardrails.py
+++ b/tests/unit/test_check_context7_guardrails.py
@@ -41,6 +41,12 @@ def test_context7_guardrails_pass_with_required_snippets(tmp_path: Path):
                         },
                         "filesystem": {
                             "url": "http://127.0.0.1:3014/mcp",
+                        },
+                        "dockerCompose": {
+                            "url": "http://127.0.0.1:3015/mcp",
+                        },
+                        "testRunner": {
+                            "url": "http://127.0.0.1:3016/mcp",
                         }
                     }
                 }

--- a/tests/unit/test_mcp_devops_docker_compose.py
+++ b/tests/unit/test_mcp_devops_docker_compose.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from apps.mcp.devops.docker_compose_service import DockerComposeService
+
+
+def _service(tmp_path: Path) -> DockerComposeService:
+    compose_file = tmp_path / "docker-compose.yml"
+    compose_file.write_text("services: {}\n", encoding="utf-8")
+    return DockerComposeService(
+        repo_root=tmp_path,
+        compose_targets={"main": "docker-compose.yml"},
+        audit_dir=tmp_path / ".tmp" / "mcp-docker-compose",
+    )
+
+
+def test_compose_up_builds_expected_command(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    service = _service(tmp_path)
+
+    captured: dict[str, list[str]] = {}
+
+    def fake_run(command: list[str], cwd: Path, capture_output: bool, text: bool, check: bool) -> subprocess.CompletedProcess[str]:
+        captured["command"] = command
+        return subprocess.CompletedProcess(command, 0, stdout="ok\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = service.compose_up(target="main", build=True, detach=True)
+
+    assert result["status"] == "ok"
+    assert captured["command"] == ["docker", "compose", "-f", "docker-compose.yml", "up", "--build", "-d"]
+
+
+def test_compose_rejects_unknown_target(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    with pytest.raises(ValueError):
+        service.compose_ps(target="missing")

--- a/tests/unit/test_mcp_devops_test_runner.py
+++ b/tests/unit/test_mcp_devops_test_runner.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from apps.mcp.devops.test_runner_service import TestRunnerService, TestRunnerServiceError
+
+
+def _service(tmp_path: Path) -> TestRunnerService:
+    return TestRunnerService(
+        repo_root=tmp_path,
+        audit_dir=tmp_path / ".tmp" / "mcp-test-runner",
+    )
+
+
+def test_profiles_include_backend_and_frontend(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    profiles = service.list_profiles()["profiles"]
+    names = {profile["name"] for profile in profiles}
+
+    assert "backend.tests" in names
+    assert "frontend.build" in names
+
+
+def test_run_profile_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    service = _service(tmp_path)
+
+    def fake_run(*args, **kwargs) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(kwargs.get("args", []), 0, stdout="passed\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = service.run_profile("backend.tests_quick")
+
+    assert result["status"] == "ok"
+    assert result["exit_code"] == 0
+
+
+def test_run_profile_failure_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    service = _service(tmp_path)
+
+    def fake_run(*args, **kwargs) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(kwargs.get("args", []), 1, stdout="", stderr="boom")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(TestRunnerServiceError):
+        service.run_profile("backend.tests")

--- a/tests/unit/test_mcp_repo_fundamentals_search.py
+++ b/tests/unit/test_mcp_repo_fundamentals_search.py
@@ -54,3 +54,38 @@ def test_scope_blocks_traversal(tmp_path: Path) -> None:
     service = SearchService(repo_root=tmp_path)
     with pytest.raises(PathGuardError):
         service.search("x", scope="../")
+
+
+def test_search_excludes_forbidden_subtrees_when_scope_is_repo_root(tmp_path: Path) -> None:
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "visible.md").write_text("needle\n", encoding="utf-8")
+
+    (tmp_path / "projectDocs").mkdir()
+    (tmp_path / "projectDocs" / "hidden.md").write_text("needle\n", encoding="utf-8")
+
+    (tmp_path / "configs").mkdir()
+    (tmp_path / "configs" / "llm.json").write_text('{"token":"needle"}\n', encoding="utf-8")
+
+    service = SearchService(repo_root=tmp_path)
+    result = service.search("needle", scope=".", include_glob="**/*")
+
+    assert result["count"] == 1
+    assert result["matches"][0]["path"] == "docs/visible.md"
+
+
+def test_list_files_excludes_forbidden_subtrees_when_scope_is_repo_root(tmp_path: Path) -> None:
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "visible.md").write_text("ok\n", encoding="utf-8")
+
+    (tmp_path / "projectDocs").mkdir()
+    (tmp_path / "projectDocs" / "hidden.md").write_text("ok\n", encoding="utf-8")
+
+    (tmp_path / "configs").mkdir()
+    (tmp_path / "configs" / "llm.json").write_text('{"model":"x"}\n', encoding="utf-8")
+
+    service = SearchService(repo_root=tmp_path)
+    result = service.list_files(scope=".", include_glob="**/*")
+
+    assert "docs/visible.md" in result["files"]
+    assert "projectDocs/hidden.md" not in result["files"]
+    assert "configs/llm.json" not in result["files"]


### PR DESCRIPTION
## Summary\n- harden Search MCP with ripgrep backend and enforced excludes for  and \n- add Git MCP  and  tools\n- add dedicated Docker/Compose MCP and Test Runner MCP servers (localhost-bound, audited logs under )\n- wire VS Code MCP settings and guardrail checks for new servers\n- add docs + compose smoke test covering all MCP endpoints\n\n## Validation\n-  targeted unit suite passed (23 tests)\n- [smoke] MCP compose smoke test
[ok] context7 running in compose project context7-mcp
[ok] bash-gateway-mcp running in compose project ai-agent-framework
[ok] git-mcp running in compose project repo-fundamentals-mcp
[ok] search-mcp running in compose project repo-fundamentals-mcp
[ok] filesystem-mcp running in compose project repo-fundamentals-mcp
[ok] docker-compose-mcp running in compose project devops-mcp
[ok] test-runner-mcp running in compose project devops-mcp
[ok] Context7 MCP endpoint reachable (406)
[ok] Bash Gateway MCP endpoint reachable (406)
[ok] Git MCP endpoint reachable (406)
[ok] Search MCP endpoint reachable (406)
[ok] Filesystem MCP endpoint reachable (406)
[ok] Docker Compose MCP endpoint reachable (406)
[ok] Test Runner MCP endpoint reachable (406)
[smoke] PASS passed\n\n## Notes\n- Existing unrelated failures in full quick test run remain in  due YAML parse issue in  (pre-existing).