### PR TITLE
feat(mcp): add offline docs index MCP with boot startup

### DIFF
--- a/.github/prompts/modules/prompt-quality-baseline.md
+++ b/.github/prompts/modules/prompt-quality-baseline.md
@@ -37,7 +37,7 @@ precedence and usage model:
 7. Use `bashGateway` MCP only for allowlisted script workflows or when a
 	required domain action has no dedicated MCP capability.
 8. For external API/library docs, use Context7 when online; when offline, use
-	local MCP search on repository docs.
+	`offlineDocs` MCP for indexed local docs; use `search` MCP as fallback only.
 
 Prompts must treat these as hard rules, not preferences.
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -149,6 +149,9 @@
       },
       "testRunner": {
         "url": "http://127.0.0.1:3016/mcp"
+      },
+      "offlineDocs": {
+        "url": "http://127.0.0.1:3017/mcp"
       }
     }
   },

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This system provides intelligent project management following ISO 21500 standard
 - 🛡️ **[Bash Gateway MCP Setup (VS Code + Docker)](docs/howto/mcp-bash-gateway.md)** - Policy-allowlisted script execution via local MCP server
 - 🧱 **[Repo Fundamentals MCP Setup](docs/howto/mcp-repo-fundamentals.md)** - Git/Search/Filesystem MCP servers
 - ⚙️ **[DevOps MCP Setup](docs/howto/mcp-devops.md)** - Docker/Compose + Test Runner MCP servers
+- 📚 **[Offline Docs MCP Setup](docs/howto/mcp-offline-docs.md)** - Local SQLite docs index for fully offline docs grounding
 - 📏 **[MCP Tool Arbitration Hard Rules](docs/howto/mcp-routing-rules.md)** - Strict tool-selection precedence for ambiguous tasks
 
 Boot-time setup helper (all MCP services):

--- a/apps/mcp/offline_docs/server.py
+++ b/apps/mcp/offline_docs/server.py
@@ -1,0 +1,68 @@
+import os
+from pathlib import Path
+
+import uvicorn
+from mcp.server.fastmcp import FastMCP
+
+from .service import OfflineDocsService, OfflineDocsServiceError
+
+
+def _load_service() -> OfflineDocsService:
+    repo_root = Path(os.getenv("OFFLINE_DOCS_MCP_REPO_ROOT", "/workspace")).resolve()
+    index_db = Path(
+        os.getenv(
+            "OFFLINE_DOCS_INDEX_DB",
+            str(repo_root / ".tmp" / "mcp-offline-docs" / "docs_index.db"),
+        )
+    ).resolve()
+    source_env = os.getenv("OFFLINE_DOCS_INDEX_SOURCES", "docs,README.md,QUICKSTART.md,templates")
+    source_paths = [item.strip() for item in source_env.split(",") if item.strip()]
+    return OfflineDocsService(repo_root=repo_root, index_db_path=index_db, source_paths=source_paths)
+
+
+service = _load_service()
+mcp = FastMCP("AI-Agent-Framework Offline Docs MCP", json_response=True)
+
+
+@mcp.tool()
+def offline_docs_index_rebuild() -> dict:
+    """Rebuild offline docs index from configured local repository sources."""
+    try:
+        return service.rebuild_index()
+    except (OfflineDocsServiceError, ValueError) as exc:
+        raise ValueError(str(exc)) from exc
+
+
+@mcp.tool()
+def offline_docs_index_stats() -> dict:
+    """Return index statistics and configured sources."""
+    return service.stats()
+
+
+@mcp.tool()
+def offline_docs_search(query: str, max_results: int = 20) -> dict:
+    """Search indexed local docs without any network dependency."""
+    try:
+        return service.search(query=query, max_results=max_results)
+    except (OfflineDocsServiceError, ValueError) as exc:
+        raise ValueError(str(exc)) from exc
+
+
+@mcp.tool()
+def offline_docs_read(path: str, start_line: int = 1, end_line: int = 200) -> dict:
+    """Read indexed local doc content by path and line range."""
+    try:
+        return service.read_document(path=path, start_line=start_line, end_line=end_line)
+    except (OfflineDocsServiceError, ValueError) as exc:
+        raise ValueError(str(exc)) from exc
+
+
+def main() -> None:
+    host = os.getenv("OFFLINE_DOCS_MCP_HOST", "0.0.0.0")
+    port = int(os.getenv("OFFLINE_DOCS_MCP_PORT", "3017"))
+    app = mcp.streamable_http_app()
+    uvicorn.run(app, host=host, port=port)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/mcp/offline_docs/service.py
+++ b/apps/mcp/offline_docs/service.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from apps.mcp.repo_fundamentals.path_guard import RepoPathGuard
+
+
+class OfflineDocsServiceError(RuntimeError):
+    """Raised when offline docs index/search operations fail."""
+
+
+@dataclass
+class OfflineDocsService:
+    repo_root: Path
+    index_db_path: Path
+    source_paths: list[str]
+
+    def __post_init__(self) -> None:
+        self.repo_root = self.repo_root.resolve()
+        self.index_db_path = self.index_db_path.resolve()
+        self.index_db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.path_guard = RepoPathGuard(self.repo_root)
+        self.text_extensions = {".md", ".txt", ".rst", ".j2", ".yml", ".yaml", ".json"}
+        self._init_db()
+
+    def _connect(self) -> sqlite3.Connection:
+        return sqlite3.connect(self.index_db_path)
+
+    def _init_db(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS docs (
+                  path TEXT PRIMARY KEY,
+                  content TEXT NOT NULL,
+                  line_count INTEGER NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE VIRTUAL TABLE IF NOT EXISTS docs_fts
+                USING fts5(path UNINDEXED, content)
+                """
+            )
+
+    def _iter_source_files(self) -> list[Path]:
+        files: list[Path] = []
+        for source in self.source_paths:
+            resolved = self.path_guard.resolve_relative_path(source, allow_nonexistent=False)
+            if resolved.is_file():
+                files.append(resolved)
+                continue
+
+            for candidate in resolved.rglob("*"):
+                if not candidate.is_file():
+                    continue
+                if candidate.suffix.lower() not in self.text_extensions:
+                    continue
+                files.append(candidate)
+
+        unique_files: dict[str, Path] = {}
+        for file_path in files:
+            relative = file_path.relative_to(self.repo_root).as_posix()
+            unique_files[relative] = file_path
+
+        return [unique_files[key] for key in sorted(unique_files.keys())]
+
+    def _load_file(self, file_path: Path) -> tuple[str, int]:
+        try:
+            content = file_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            return "", 0
+        return content, len(content.splitlines())
+
+    def rebuild_index(self) -> dict[str, Any]:
+        indexed = 0
+        skipped = 0
+
+        with self._connect() as conn:
+            conn.execute("DELETE FROM docs")
+            conn.execute("DELETE FROM docs_fts")
+
+            for file_path in self._iter_source_files():
+                relative = file_path.relative_to(self.repo_root).as_posix()
+                content, line_count = self._load_file(file_path)
+                if not content:
+                    skipped += 1
+                    continue
+
+                conn.execute(
+                    "INSERT INTO docs(path, content, line_count) VALUES (?, ?, ?)",
+                    (relative, content, line_count),
+                )
+                conn.execute(
+                    "INSERT INTO docs_fts(path, content) VALUES (?, ?)",
+                    (relative, content),
+                )
+                indexed += 1
+
+        return {
+            "indexed_files": indexed,
+            "skipped_files": skipped,
+            "index_db": str(self.index_db_path),
+        }
+
+    def ensure_index(self) -> None:
+        with self._connect() as conn:
+            row = conn.execute("SELECT COUNT(*) FROM docs").fetchone()
+            doc_count = int(row[0]) if row else 0
+        if doc_count == 0:
+            self.rebuild_index()
+
+    def stats(self) -> dict[str, Any]:
+        self.ensure_index()
+        with self._connect() as conn:
+            row = conn.execute("SELECT COUNT(*) FROM docs").fetchone()
+            doc_count = int(row[0]) if row else 0
+
+        return {
+            "doc_count": doc_count,
+            "index_db": str(self.index_db_path),
+            "source_paths": self.source_paths,
+        }
+
+    def _line_number_for_match(self, content: str, query: str) -> int:
+        query_lower = query.lower()
+        for line_no, line in enumerate(content.splitlines(), start=1):
+            if query_lower in line.lower():
+                return line_no
+        return 1
+
+    def search(self, query: str, max_results: int = 20) -> dict[str, Any]:
+        query_text = query.strip()
+        if not query_text:
+            raise ValueError("query is required")
+        if max_results <= 0 or max_results > 200:
+            raise ValueError("max_results must be between 1 and 200")
+
+        self.ensure_index()
+
+        with self._connect() as conn:
+            try:
+                rows = conn.execute(
+                    """
+                    SELECT docs.path, docs.content
+                    FROM docs_fts
+                    JOIN docs ON docs.path = docs_fts.path
+                    WHERE docs_fts MATCH ?
+                    LIMIT ?
+                    """,
+                    (query_text, max_results),
+                ).fetchall()
+            except sqlite3.OperationalError:
+                rows = conn.execute(
+                    "SELECT path, content FROM docs WHERE content LIKE ? LIMIT ?",
+                    (f"%{query_text}%", max_results),
+                ).fetchall()
+
+        matches: list[dict[str, Any]] = []
+        for path, content in rows:
+            line_no = self._line_number_for_match(content, query_text)
+            lines = content.splitlines()
+            snippet = lines[line_no - 1] if 1 <= line_no <= len(lines) else ""
+            matches.append(
+                {
+                    "path": path,
+                    "line": line_no,
+                    "snippet": snippet,
+                }
+            )
+
+        return {
+            "query": query_text,
+            "count": len(matches),
+            "matches": matches,
+        }
+
+    def read_document(self, path: str, start_line: int = 1, end_line: int = 200) -> dict[str, Any]:
+        if start_line <= 0 or end_line <= 0:
+            raise ValueError("start_line and end_line must be >= 1")
+        if end_line < start_line:
+            raise ValueError("end_line must be >= start_line")
+
+        resolved = self.path_guard.resolve_relative_path(path, allow_nonexistent=False)
+        relative = resolved.relative_to(self.repo_root).as_posix()
+
+        with self._connect() as conn:
+            row = conn.execute("SELECT content, line_count FROM docs WHERE path = ?", (relative,)).fetchone()
+
+        if not row:
+            raise OfflineDocsServiceError(
+                f"Document not indexed: {relative}. Run offline_docs_index_rebuild first."
+            )
+
+        content, line_count = row
+        lines = str(content).splitlines()
+        selected = lines[start_line - 1 : end_line]
+
+        return {
+            "path": relative,
+            "start_line": start_line,
+            "end_line": min(end_line, int(line_count)),
+            "content": "\n".join(selected),
+        }

--- a/docker-compose.mcp-offline-docs.yml
+++ b/docker-compose.mcp-offline-docs.yml
@@ -1,0 +1,19 @@
+name: offline-docs-mcp
+
+services:
+  offline-docs-mcp:
+    build:
+      context: .
+      dockerfile: docker/mcp-offline-docs/Dockerfile
+    container_name: offline-docs-mcp
+    restart: unless-stopped
+    environment:
+      - OFFLINE_DOCS_MCP_PORT=3017
+      - OFFLINE_DOCS_MCP_HOST=0.0.0.0
+      - OFFLINE_DOCS_MCP_REPO_ROOT=/workspace
+      - OFFLINE_DOCS_INDEX_DB=/workspace/.tmp/mcp-offline-docs/docs_index.db
+      - OFFLINE_DOCS_INDEX_SOURCES=docs,README.md,QUICKSTART.md,templates
+    ports:
+      - "127.0.0.1:3017:3017"
+    volumes:
+      - ./:/workspace

--- a/docker/mcp-offline-docs/Dockerfile
+++ b/docker/mcp-offline-docs/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    OFFLINE_DOCS_MCP_PORT=3017 \
+    OFFLINE_DOCS_MCP_REPO_ROOT=/workspace
+
+WORKDIR /workspace
+
+RUN pip install --no-cache-dir \
+    mcp==1.12.4 \
+    uvicorn[standard]==0.27.0
+
+EXPOSE 3017
+
+CMD ["python", "-m", "apps.mcp.offline_docs.server"]

--- a/docs/howto/mcp-devops.md
+++ b/docs/howto/mcp-devops.md
@@ -31,7 +31,7 @@ chmod +x scripts/install-devops-mcp-systemd.sh
 ./scripts/install-devops-mcp-systemd.sh
 ```
 
-Install all MCP services (Context7, Bash Gateway, Repo Fundamentals, DevOps):
+Install all MCP services (Context7, Bash Gateway, Repo Fundamentals, DevOps, Offline Docs):
 
 ```bash
 chmod +x scripts/install-all-mcp-systemd.sh

--- a/docs/howto/mcp-offline-docs.md
+++ b/docs/howto/mcp-offline-docs.md
@@ -1,0 +1,66 @@
+# MCP Offline Docs Index (Local-Only Grounding)
+
+This MCP server provides Context7-like docs grounding with no network dependency
+by indexing local repository docs into a SQLite full-text index.
+
+- Offline Docs MCP: `http://127.0.0.1:3017/mcp`
+
+## Start with Docker Compose
+
+```bash
+docker compose -f docker-compose.mcp-offline-docs.yml up -d --build
+```
+
+## Endpoint check
+
+```bash
+curl -sS -o /dev/null -w "%{http_code}\n" http://127.0.0.1:3017/mcp
+```
+
+Expected for plain curl: `406`.
+
+## Boot-time startup (systemd)
+
+Install only Offline Docs MCP:
+
+```bash
+chmod +x scripts/install-offline-docs-mcp-systemd.sh
+./scripts/install-offline-docs-mcp-systemd.sh
+```
+
+Install all MCP services:
+
+```bash
+chmod +x scripts/install-all-mcp-systemd.sh
+./scripts/install-all-mcp-systemd.sh
+```
+
+## Indexed sources
+
+By default the index includes:
+
+- `docs/`
+- `README.md`
+- `QUICKSTART.md`
+- `templates/`
+
+Override via env file `/etc/default/offline-docs-mcp`:
+
+```bash
+OFFLINE_DOCS_INDEX_SOURCES=docs,README.md,QUICKSTART.md,templates
+OFFLINE_DOCS_INDEX_DB=/workspace/.tmp/mcp-offline-docs/docs_index.db
+```
+
+## Core tools
+
+- `offline_docs_index_rebuild`
+- `offline_docs_index_stats`
+- `offline_docs_search`
+- `offline_docs_read`
+
+## Validation
+
+```bash
+python3 scripts/check_mcp_connections.py
+bash scripts/mcp_smoke_test.sh
+```

--- a/docs/howto/mcp-routing-rules.md
+++ b/docs/howto/mcp-routing-rules.md
@@ -47,13 +47,13 @@ Use `bashGateway` MCP only when:
 ## Rule 8: External docs grounding
 
 Use Context7 when online for external APIs/frameworks.
-When offline, use local repository docs via `search` MCP (`docs/`, `README.md`,
-`templates/`).
+When offline, use `offlineDocs` MCP first for indexed local docs.
+Use `search` MCP only as fallback when required content is not indexed.
 
 ## Rule 9: Tie-breaker
 
 If uncertainty remains, enforce this strict precedence order:
 
-`git/search/filesystem/dockerCompose/testRunner` (domain MCP) > `bashGateway` > generic terminal.
+`git/search/filesystem/dockerCompose/testRunner/offlineDocs` (domain MCP) > `bashGateway` > generic terminal.
 
 No lower-tier tool may be chosen when a higher-tier, capable tool is available.

--- a/scripts/check_context7_guardrails.py
+++ b/scripts/check_context7_guardrails.py
@@ -41,6 +41,7 @@ REQUIRED_MCP_SERVER_URLS = {
     "filesystem": "http://127.0.0.1:3014/mcp",
     "dockerCompose": "http://127.0.0.1:3015/mcp",
     "testRunner": "http://127.0.0.1:3016/mcp",
+    "offlineDocs": "http://127.0.0.1:3017/mcp",
 }
 
 

--- a/scripts/check_mcp_connections.py
+++ b/scripts/check_mcp_connections.py
@@ -19,6 +19,7 @@ EXPECTED_MCP_SERVERS = {
     "filesystem": "http://127.0.0.1:3014/mcp",
     "dockerCompose": "http://127.0.0.1:3015/mcp",
     "testRunner": "http://127.0.0.1:3016/mcp",
+    "offlineDocs": "http://127.0.0.1:3017/mcp",
 }
 
 

--- a/scripts/install-all-mcp-systemd.sh
+++ b/scripts/install-all-mcp-systemd.sh
@@ -13,5 +13,6 @@ run_step "scripts/install-context7-systemd.sh"
 run_step "scripts/install-bash-gateway-mcp-systemd.sh"
 run_step "scripts/install-repo-fundamentals-mcp-systemd.sh"
 run_step "scripts/install-devops-mcp-systemd.sh"
+run_step "scripts/install-offline-docs-mcp-systemd.sh"
 
 echo "[ok] All MCP systemd services installed and enabled"

--- a/scripts/install-offline-docs-mcp-systemd.sh
+++ b/scripts/install-offline-docs-mcp-systemd.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="${ROOT_DIR}/docker-compose.mcp-offline-docs.yml"
+PROJECT_NAME="offline-docs-mcp"
+UNIT_NAME="offline-docs-mcp.service"
+UNIT_PATH="/etc/systemd/system/${UNIT_NAME}"
+ENV_FILE="/etc/default/offline-docs-mcp"
+DOCKER_BIN="$(command -v docker || true)"
+SYSTEMCTL_BIN="$(command -v systemctl || true)"
+SUDO_BIN="$(command -v sudo || true)"
+
+if [[ -z "${DOCKER_BIN}" ]]; then
+  echo "docker command not found. Install Docker first."
+  exit 1
+fi
+
+if [[ -z "${SYSTEMCTL_BIN}" ]]; then
+  echo "systemctl not found. This script requires systemd."
+  exit 1
+fi
+
+if [[ -z "${SUDO_BIN}" ]]; then
+  echo "sudo command not found. This script requires sudo for unit installation."
+  exit 1
+fi
+
+if [[ ! -d /run/systemd/system ]]; then
+  echo "systemd does not appear to be active on this host."
+  exit 1
+fi
+
+if [[ ! -f "${COMPOSE_FILE}" ]]; then
+  echo "Compose file not found: ${COMPOSE_FILE}"
+  exit 1
+fi
+
+if ! "${DOCKER_BIN}" compose version >/dev/null 2>&1; then
+  echo "docker compose plugin not found. Install Docker Compose v2 support."
+  exit 1
+fi
+
+if [[ ! -f "${ENV_FILE}" ]]; then
+  sudo tee "${ENV_FILE}" >/dev/null <<'EOF'
+# Optional overrides for Offline Docs MCP service
+# OFFLINE_DOCS_INDEX_SOURCES=docs,README.md,QUICKSTART.md,templates
+# OFFLINE_DOCS_INDEX_DB=/workspace/.tmp/mcp-offline-docs/docs_index.db
+EOF
+  sudo chmod 0600 "${ENV_FILE}"
+  echo "Created ${ENV_FILE} template."
+fi
+
+sudo tee "${UNIT_PATH}" >/dev/null <<EOF
+[Unit]
+Description=Offline Docs MCP Docker Service
+After=docker.service network-online.target
+Wants=network-online.target
+Requires=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+EnvironmentFile=-${ENV_FILE}
+WorkingDirectory=${ROOT_DIR}
+ExecStart=${DOCKER_BIN} compose --project-name ${PROJECT_NAME} -f ${COMPOSE_FILE} up -d --build --remove-orphans
+ExecStop=${DOCKER_BIN} compose --project-name ${PROJECT_NAME} -f ${COMPOSE_FILE} down --remove-orphans
+ExecReload=${DOCKER_BIN} compose --project-name ${PROJECT_NAME} -f ${COMPOSE_FILE} up -d --build --remove-orphans
+TimeoutStartSec=600
+TimeoutStopSec=120
+UMask=0077
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo chmod 0644 "${UNIT_PATH}"
+sudo systemctl daemon-reload
+sudo systemctl enable --now "${UNIT_NAME}"
+
+echo "Installed and started ${UNIT_NAME}."
+echo "Environment file: ${ENV_FILE}"
+echo "Check status with: sudo systemctl status ${UNIT_NAME}"
+echo "Enabled: $(sudo systemctl is-enabled "${UNIT_NAME}")"
+echo "Active: $(sudo systemctl is-active "${UNIT_NAME}")"

--- a/scripts/mcp_smoke_test.sh
+++ b/scripts/mcp_smoke_test.sh
@@ -50,6 +50,7 @@ check_systemd "context7-mcp.service"
 check_systemd "bash-gateway-mcp.service"
 check_systemd "repo-fundamentals-mcp.service"
 check_systemd "devops-mcp.service"
+check_systemd "offline-docs-mcp.service"
 
 check_compose_service "context7-mcp" "$ROOT_DIR/docker-compose.context7.yml" "context7"
 check_compose_service "ai-agent-framework" "$ROOT_DIR/docker-compose.mcp-bash-gateway.yml" "bash-gateway-mcp"
@@ -58,6 +59,7 @@ check_compose_service "repo-fundamentals-mcp" "$ROOT_DIR/docker-compose.repo-fun
 check_compose_service "repo-fundamentals-mcp" "$ROOT_DIR/docker-compose.repo-fundamentals-mcp.yml" "filesystem-mcp"
 check_compose_service "devops-mcp" "$ROOT_DIR/docker-compose.mcp-devops.yml" "docker-compose-mcp"
 check_compose_service "devops-mcp" "$ROOT_DIR/docker-compose.mcp-devops.yml" "test-runner-mcp"
+check_compose_service "offline-docs-mcp" "$ROOT_DIR/docker-compose.mcp-offline-docs.yml" "offline-docs-mcp"
 
 check_endpoint_406 "Context7 MCP" "http://127.0.0.1:3010/mcp"
 check_endpoint_406 "Bash Gateway MCP" "http://127.0.0.1:3011/mcp"
@@ -66,6 +68,7 @@ check_endpoint_406 "Search MCP" "http://127.0.0.1:3013/mcp"
 check_endpoint_406 "Filesystem MCP" "http://127.0.0.1:3014/mcp"
 check_endpoint_406 "Docker Compose MCP" "http://127.0.0.1:3015/mcp"
 check_endpoint_406 "Test Runner MCP" "http://127.0.0.1:3016/mcp"
+check_endpoint_406 "Offline Docs MCP" "http://127.0.0.1:3017/mcp"
 
 python3 "$ROOT_DIR/scripts/check_mcp_connections.py"
 

--- a/scripts/mcp_smoke_test_compose.sh
+++ b/scripts/mcp_smoke_test_compose.sh
@@ -41,6 +41,7 @@ check_compose_service "repo-fundamentals-mcp" "$ROOT_DIR/docker-compose.repo-fun
 check_compose_service "repo-fundamentals-mcp" "$ROOT_DIR/docker-compose.repo-fundamentals-mcp.yml" "filesystem-mcp"
 check_compose_service "devops-mcp" "$ROOT_DIR/docker-compose.mcp-devops.yml" "docker-compose-mcp"
 check_compose_service "devops-mcp" "$ROOT_DIR/docker-compose.mcp-devops.yml" "test-runner-mcp"
+check_compose_service "offline-docs-mcp" "$ROOT_DIR/docker-compose.mcp-offline-docs.yml" "offline-docs-mcp"
 
 check_endpoint_406 "Context7 MCP" "http://127.0.0.1:3010/mcp"
 check_endpoint_406 "Bash Gateway MCP" "http://127.0.0.1:3011/mcp"
@@ -49,6 +50,7 @@ check_endpoint_406 "Search MCP" "http://127.0.0.1:3013/mcp"
 check_endpoint_406 "Filesystem MCP" "http://127.0.0.1:3014/mcp"
 check_endpoint_406 "Docker Compose MCP" "http://127.0.0.1:3015/mcp"
 check_endpoint_406 "Test Runner MCP" "http://127.0.0.1:3016/mcp"
+check_endpoint_406 "Offline Docs MCP" "http://127.0.0.1:3017/mcp"
 
 python3 "$ROOT_DIR/scripts/check_mcp_connections.py"
 

--- a/tests/unit/test_check_context7_guardrails.py
+++ b/tests/unit/test_check_context7_guardrails.py
@@ -47,6 +47,9 @@ def test_context7_guardrails_pass_with_required_snippets(tmp_path: Path):
                         },
                         "testRunner": {
                             "url": "http://127.0.0.1:3016/mcp",
+                        },
+                        "offlineDocs": {
+                            "url": "http://127.0.0.1:3017/mcp",
                         }
                     }
                 }

--- a/tests/unit/test_mcp_offline_docs_service.py
+++ b/tests/unit/test_mcp_offline_docs_service.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from apps.mcp.offline_docs.service import OfflineDocsService
+
+
+def _service(tmp_path: Path) -> OfflineDocsService:
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    (docs_dir / "guide.md").write_text("alpha line\nbeta line\n", encoding="utf-8")
+    (tmp_path / "README.md").write_text("project intro\n", encoding="utf-8")
+
+    return OfflineDocsService(
+        repo_root=tmp_path,
+        index_db_path=tmp_path / ".tmp" / "mcp-offline-docs" / "docs_index.db",
+        source_paths=["docs", "README.md"],
+    )
+
+
+def test_rebuild_and_stats(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    result = service.rebuild_index()
+
+    assert result["indexed_files"] >= 2
+    stats = service.stats()
+    assert stats["doc_count"] >= 2
+
+
+def test_search_and_read(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    service.rebuild_index()
+
+    found = service.search("beta", max_results=5)
+    assert found["count"] >= 1
+    assert found["matches"][0]["path"] == "docs/guide.md"
+
+    excerpt = service.read_document("docs/guide.md", start_line=2, end_line=2)
+    assert excerpt["content"] == "beta line"


### PR DESCRIPTION
## Summary
- add a new Offline Docs MCP server (SQLite indexed local docs, fully offline)
- expose `offlineDocs` MCP endpoint on `http://127.0.0.1:3017/mcp`
- add Docker compose + image for offline docs MCP
- add systemd installer for offline docs MCP and include it in install-all
- extend smoke tests and connection checks to include offline docs MCP
- update hard routing rules to prefer `offlineDocs` for offline docs grounding

## Validation
- runTests: `tests/unit/test_mcp_offline_docs_service.py`, `tests/unit/test_check_context7_guardrails.py` (passed)
- `python3 scripts/check_mcp_connections.py` (passed)
- `bash scripts/mcp_smoke_test_compose.sh` (passed)
- `bash scripts/mcp_smoke_test.sh` (passed)
- `bash scripts/install-offline-docs-mcp-systemd.sh` + `bash scripts/install-all-mcp-systemd.sh` (enabled+active)

## Outcome
- all MCP services now include offline docs MCP at boot
- local offline docs grounding is implemented without network dependency
