### PR TITLE
docs: clarify offlineDocs vs search routing precedence

### DIFF
--- a/.github/prompts/modules/prompt-quality-baseline.md
+++ b/.github/prompts/modules/prompt-quality-baseline.md
@@ -26,7 +26,7 @@ precedence and usage model:
 1. Prefer the most specialized domain MCP server over generic servers.
 2. Use `git` MCP for repository history/state operations (`status`, `diff`,
 	`log`, `show`, `blame`, branch tasks).
-3. Use `search` MCP for code/doc content discovery and text matching before
+3. Use `search` MCP for codebase content discovery and text matching before
 	file reads.
 4. Use `filesystem` MCP for deterministic file CRUD inside workspace scope;
 	never use it for git-history questions.
@@ -37,7 +37,11 @@ precedence and usage model:
 7. Use `bashGateway` MCP only for allowlisted script workflows or when a
 	required domain action has no dedicated MCP capability.
 8. For external API/library docs, use Context7 when online; when offline, use
-	`offlineDocs` MCP for indexed local docs; use `search` MCP as fallback only.
+	`offlineDocs` MCP for indexed local docs; use `search` MCP only when
+	`offlineDocs` does not cover required content.
+
+9. For local docs Q&A on repository documentation, prefer `offlineDocs` MCP for
+	index/search/read; use `filesystem` read only for exact-path excerpts.
 
 Prompts must treat these as hard rules, not preferences.
 

--- a/docs/howto/mcp-routing-rules.md
+++ b/docs/howto/mcp-routing-rules.md
@@ -17,9 +17,9 @@ Use `git` MCP for:
 
 Do not use `filesystem` or generic shell paths for git-history reasoning.
 
-## Rule 3: Content discovery -> Search MCP
+## Rule 3: Code discovery -> Search MCP
 
-Use `search` MCP first for code/doc discovery and text matching.
+Use `search` MCP first for codebase discovery and text matching.
 Only use direct file reads when the target path is already known.
 
 ## Rule 4: File CRUD -> Filesystem MCP
@@ -50,10 +50,21 @@ Use Context7 when online for external APIs/frameworks.
 When offline, use `offlineDocs` MCP first for indexed local docs.
 Use `search` MCP only as fallback when required content is not indexed.
 
-## Rule 9: Tie-breaker
+## Rule 9: Local docs Q&A -> Offline Docs MCP
 
-If uncertainty remains, enforce this strict precedence order:
+For repository documentation Q&A and grounding (docs/tutorials/readmes/templates),
+prefer `offlineDocs` MCP for index/search/read operations.
+Use `filesystem` reads only for exact-path excerpts after the document is known.
 
-`git/search/filesystem/dockerCompose/testRunner/offlineDocs` (domain MCP) > `bashGateway` > generic terminal.
+## Rule 10: Tie-breaker
+
+If uncertainty remains, enforce precedence by task class:
+
+- Git/history/state: `git` > `bashGateway` > terminal
+- Code discovery: `search` > `filesystem` read > terminal
+- Local docs grounding/Q&A: `offlineDocs` > `search` > `filesystem` read
+- File CRUD: `filesystem` > `bashGateway` > terminal
+- Compose/containers: `dockerCompose` > `bashGateway` > terminal
+- Lint/build/test: `testRunner` > `bashGateway` > terminal
 
 No lower-tier tool may be chosen when a higher-tier, capable tool is available.


### PR DESCRIPTION
# Summary
Clarify hard MCP routing precedence between offline docs lookup and repository search.

## Goal / Acceptance Criteria (required)
- [x] Remove ambiguity between offlineDocs and search tool selection rules
- [x] Document explicit precedence by task class (docs lookup vs code search)
- [x] Keep guardrail checks passing

## Issue / Tracking Link (required)
- Tracking follow-up to PR #576 re-review
- Fixes: #577

## Validation (required)
- `python3 scripts/check_context7_guardrails.py` passed
- `pytest tests/unit/test_check_context7_guardrails.py` passed

## Automated checks
- Evidence: repository has no required checks configured for this PR; merge executed with `PRMERGE_ALLOW_NO_REQUIRED_CHECKS=1`

## Manual test evidence (required)
- Reviewed `.github/prompts/modules/prompt-quality-baseline.md` wording for explicit offlineDocs/search arbitration
- Reviewed `docs/howto/mcp-routing-rules.md` routing matrix for task-specific precedence