### PR TITLE
feat: auto-refresh offline docs index on source changes

### DIFF
--- a/.github/prompts/modules/prompt-quality-baseline.md
+++ b/.github/prompts/modules/prompt-quality-baseline.md
@@ -42,6 +42,8 @@ precedence and usage model:
 
 9. For local docs Q&A on repository documentation, prefer `offlineDocs` MCP for
 	index/search/read; use `filesystem` read only for exact-path excerpts.
+10. Keep `offlineDocs` index lifecycle change-driven: refresh after `docs/` or
+	`templates/` source changes; do not require boot-time rebuilds.
 
 Prompts must treat these as hard rules, not preferences.
 

--- a/docs/howto/mcp-offline-docs.md
+++ b/docs/howto/mcp-offline-docs.md
@@ -58,6 +58,13 @@ OFFLINE_DOCS_INDEX_DB=/workspace/.tmp/mcp-offline-docs/docs_index.db
 - `offline_docs_search`
 - `offline_docs_read`
 
+## Index refresh policy
+
+- Keep the index DB local in `.tmp/mcp-offline-docs/docs_index.db` (never commit).
+- Rebuild is change-driven and triggered when indexed sources change (`docs/`, `templates/`, or configured source files).
+- Boot-time rebuild is not required.
+- Use `offline_docs_index_rebuild` only when you want to force a manual refresh.
+
 ## Validation
 
 ```bash

--- a/docs/howto/mcp-routing-rules.md
+++ b/docs/howto/mcp-routing-rules.md
@@ -56,6 +56,9 @@ For repository documentation Q&A and grounding (docs/tutorials/readmes/templates
 prefer `offlineDocs` MCP for index/search/read operations.
 Use `filesystem` reads only for exact-path excerpts after the document is known.
 
+Offline Docs index maintenance is change-driven: refresh after `docs/` or
+`templates/` updates, not as a boot-time requirement.
+
 ## Rule 10: Tie-breaker
 
 If uncertainty remains, enforce precedence by task class:

--- a/tests/unit/test_mcp_offline_docs_service.py
+++ b/tests/unit/test_mcp_offline_docs_service.py
@@ -37,3 +37,15 @@ def test_search_and_read(tmp_path: Path) -> None:
 
     excerpt = service.read_document("docs/guide.md", start_line=2, end_line=2)
     assert excerpt["content"] == "beta line"
+
+
+def test_index_auto_rebuilds_after_docs_change(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    service.rebuild_index()
+
+    docs_file = tmp_path / "docs" / "guide.md"
+    docs_file.write_text("alpha line\ngamma line\n", encoding="utf-8")
+
+    found = service.search("gamma", max_results=5)
+    assert found["count"] >= 1
+    assert found["matches"][0]["path"] == "docs/guide.md"


### PR DESCRIPTION
# Summary
Implement change-driven Offline Docs index refresh so docs/template edits trigger automatic reindex during normal MCP usage, without boot-time rebuild.

## Goal / Acceptance Criteria (required)
- [x] Rebuild Offline Docs index automatically when indexed sources change
- [x] Keep index local in `.tmp` and avoid boot-time rebuild requirement
- [x] Document the rule in MCP routing/baseline docs
- [x] Add unit coverage for auto-rebuild behavior

## Issue / Tracking Link (required)
- Tracking: workspace operational rule update for Offline Docs MCP index lifecycle

## Validation (required)
- `pytest tests/unit/test_mcp_offline_docs_service.py tests/unit/test_check_context7_guardrails.py`
- `python3 scripts/check_context7_guardrails.py`

## Automated checks
- Evidence: targeted unit tests and guardrail checks passed locally.

## Manual test evidence (required)
- Verified source-change flow in service logic using source fingerprint metadata.
- Verified policy/docs alignment in:
  - `.github/prompts/modules/prompt-quality-baseline.md`
  - `docs/howto/mcp-routing-rules.md`
  - `docs/howto/mcp-offline-docs.md`
