### PR TITLE
chore: add safe archive wrapper for dev supervisor

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -108,7 +108,7 @@
       "label": "🗄️ Archive Goals (.tmp)",
       "type": "shell",
       "command": "bash",
-      "args": ["${workspaceFolder}/scripts/archive-goals.sh"],
+      "args": ["${workspaceFolder}/scripts/archive-goals-safe.sh"],
       "options": {
         "cwd": "${workspaceFolder}"
       },
@@ -125,7 +125,7 @@
       "label": "🗄️ Archive Goals (.tmp, move)",
       "type": "shell",
       "command": "bash",
-      "args": ["${workspaceFolder}/scripts/archive-goals.sh", "--move"],
+      "args": ["${workspaceFolder}/scripts/archive-goals-safe.sh", "--move"],
       "options": {
         "cwd": "${workspaceFolder}"
       },

--- a/instructions.md
+++ b/instructions.md
@@ -1,0 +1,32 @@
+# Instructions
+
+## Safe Chat Archive Workflow
+
+Use the safe archive wrapper to avoid false "pending edits" warnings caused by
+live `.tmp` log churn from `dev_stack_supervisor`.
+
+- Script: `scripts/archive-goals-safe.sh`
+- VS Code tasks:
+  - `🗄️ Archive Goals (.tmp)`
+  - `🗄️ Archive Goals (.tmp, move)`
+
+### Behavior
+
+1. Detect whether `dev_stack_supervisor` is running via `.tmp/dev-stack-supervisor.pid`.
+2. If running, stop it temporarily.
+3. Execute `scripts/archive-goals.sh` with the same arguments.
+4. Restart `dev_stack_supervisor` automatically if it was running before.
+
+### Why this matters
+
+- `dev_stack_supervisor` continuously appends to `.tmp/dev-backend.log` and
+  `.tmp/dev-frontend.log`.
+- Some UI/archive flows treat this ongoing file mutation as "pending edits" even
+  when git status is clean.
+- The safe wrapper removes that race condition while preserving your dev workflow.
+
+### Notes
+
+- This does **not** change git-tracked files during archive.
+- The Offline Docs index at `.tmp/mcp-offline-docs/docs_index.db` remains local
+  and is intentionally kept between chats.

--- a/scripts/archive-goals-safe.sh
+++ b/scripts/archive-goals-safe.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SUPERVISOR_PID_FILE="${DEV_STACK_PID_FILE:-$REPO_ROOT/.tmp/dev-stack-supervisor.pid}"
+SUPERVISOR_SCRIPT="$REPO_ROOT/scripts/dev_stack_supervisor.py"
+PYTHON_BIN="$REPO_ROOT/.venv/bin/python"
+
+was_running=false
+supervisor_pid=""
+
+is_running_pid() {
+  local pid="$1"
+  if [[ -z "$pid" || ! "$pid" =~ ^[0-9]+$ ]]; then
+    return 1
+  fi
+  kill -0 "$pid" 2>/dev/null
+}
+
+stop_supervisor_if_running() {
+  if [[ ! -f "$SUPERVISOR_PID_FILE" ]]; then
+    return 0
+  fi
+
+  supervisor_pid="$(tr -d '[:space:]' < "$SUPERVISOR_PID_FILE" || true)"
+  if ! is_running_pid "$supervisor_pid"; then
+    rm -f "$SUPERVISOR_PID_FILE"
+    supervisor_pid=""
+    return 0
+  fi
+
+  was_running=true
+  echo "[archive-safe] stopping dev_stack_supervisor (pid=$supervisor_pid)"
+  kill -TERM "$supervisor_pid" 2>/dev/null || true
+
+  for _ in {1..30}; do
+    if ! is_running_pid "$supervisor_pid"; then
+      break
+    fi
+    sleep 0.2
+  done
+
+  if is_running_pid "$supervisor_pid"; then
+    echo "[archive-safe] forcing dev_stack_supervisor stop (pid=$supervisor_pid)"
+    kill -KILL "$supervisor_pid" 2>/dev/null || true
+  fi
+
+  rm -f "$SUPERVISOR_PID_FILE"
+}
+
+restart_supervisor_if_needed() {
+  if [[ "$was_running" != true ]]; then
+    return 0
+  fi
+
+  if [[ ! -x "$PYTHON_BIN" ]]; then
+    echo "[archive-safe] warning: python interpreter not found at $PYTHON_BIN; supervisor not restarted" >&2
+    return 0
+  fi
+
+  echo "[archive-safe] restarting dev_stack_supervisor"
+  nohup "$PYTHON_BIN" -u "$SUPERVISOR_SCRIPT" >/dev/null 2>&1 &
+  sleep 0.4
+}
+
+stop_supervisor_if_running
+trap 'restart_supervisor_if_needed' EXIT
+
+bash "$REPO_ROOT/scripts/archive-goals.sh" "$@"


### PR DESCRIPTION
# Summary
Add a safe archive wrapper that temporarily pauses `dev_stack_supervisor` while archiving goals to avoid false pending-edit signals from live `.tmp` log writes.

## Goal / Acceptance Criteria (required)
- [x] Add script wrapper that stops/restarts supervisor around archive flow
- [x] Route VS Code archive tasks through the safe wrapper
- [x] Document behavior and rationale in `instructions.md`

## Issue / Tracking Link (required)
- Tracking: workspace ergonomics improvement for chat/archive workflow

## Validation (required)
- `🗄️ Archive Goals (.tmp)` runs successfully via task
- Supervisor restarts automatically and PID is present afterward

## Automated checks
- Evidence: archive task output showed stop/archive/restart sequence

## Manual test evidence (required)
- Verified wrapper output in archive task terminal
- Verified supervisor process after archive run
