### PR TITLE
chore: normalize blecs UX authority naming (#552)

### DIFF
--- a/scripts/check_prompt_quality.py
+++ b/scripts/check_prompt_quality.py
@@ -29,6 +29,11 @@ REQUIRED_HEADERS = [
     "## Completion Criteria",
 ]
 
+UX_NAMING_DRIFT_PATTERNS = (
+    "blecx UX Authority Agent",
+    "blecx-ux-authority",
+)
+
 LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
 
 
@@ -73,6 +78,21 @@ def _check_broken_local_links(errors: list[str]) -> None:
                 errors.append(f"{file}: broken link -> {target}")
 
 
+def _check_ux_authority_naming_drift(errors: list[str]) -> None:
+    governance_roots = [ROOT / ".github" / "agents", ROOT / ".github" / "prompts"]
+
+    for governance_root in governance_roots:
+        if not governance_root.exists():
+            continue
+        for file in sorted(governance_root.rglob("*.md")):
+            text = _read_text(file)
+            for pattern in UX_NAMING_DRIFT_PATTERNS:
+                if pattern in text:
+                    errors.append(
+                        f"{file}: legacy UX authority naming found: '{pattern}'"
+                    )
+
+
 def _is_strict_mode() -> bool:
     return "--strict" in sys.argv
 
@@ -83,6 +103,7 @@ def main() -> int:
     _check_agent_line_limits(errors)
     _check_required_sections(errors)
     _check_broken_local_links(errors)
+    _check_ux_authority_naming_drift(errors)
 
     if errors:
         mode = "strict" if _is_strict_mode() else "baseline"

--- a/specs/001-blecs-agent-migration/tasks.md
+++ b/specs/001-blecs-agent-migration/tasks.md
@@ -10,7 +10,7 @@
 
 ## Namespace Alignment TODO (Required Before Phase 2)
 
-- [x] Rename blecx authority agent files and IDs to blecs equivalents
+- [x] Rename legacy authority agent files and IDs to blecs equivalents
 - [x] Rename old extension command files to blecs extension files (`blecs.*`)
 - [x] Update all prompt/CI/workflow references to blecs authority names
 - [x] Re-run prompt and syntax validation after namespace migration

--- a/tests/unit/test_check_prompt_quality.py
+++ b/tests/unit/test_check_prompt_quality.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+import scripts.check_prompt_quality as mod
+
+
+def test_detects_legacy_ux_authority_naming(tmp_path):
+    agents_dir = tmp_path / ".github" / "agents"
+    prompts_dir = tmp_path / ".github" / "prompts"
+    agents_dir.mkdir(parents=True)
+    prompts_dir.mkdir(parents=True)
+
+    bad_file = agents_dir / "bad.agent.md"
+    bad_file.write_text("You are the blecx UX Authority Agent.", encoding="utf-8")
+
+    original_root = mod.ROOT
+    try:
+        mod.ROOT = tmp_path
+        errors: list[str] = []
+        mod._check_ux_authority_naming_drift(errors)
+        assert errors
+        assert "legacy UX authority naming" in errors[0]
+    finally:
+        mod.ROOT = original_root
+
+
+def test_accepts_blecs_ux_authority_naming(tmp_path):
+    prompts_dir = tmp_path / ".github" / "prompts"
+    prompts_dir.mkdir(parents=True)
+
+    good_file = prompts_dir / "good.md"
+    good_file.write_text("Consult blecs-ux-authority before final UX decisions.", encoding="utf-8")
+
+    original_root = mod.ROOT
+    try:
+        mod.ROOT = tmp_path
+        errors: list[str] = []
+        mod._check_ux_authority_naming_drift(errors)
+        assert errors == []
+    finally:
+        mod.ROOT = original_root


### PR DESCRIPTION
## Summary
- adds a strict governance naming drift check for legacy UX authority aliases
- adds deterministic unit regression tests for the naming guard
- updates migration task wording to avoid legacy `blecx` UX authority naming

## Issue
Fixes #552

## Scope
- `scripts/check_prompt_quality.py`
- `tests/unit/test_check_prompt_quality.py`
- `specs/001-blecs-agent-migration/tasks.md`

## Validation
- `./.venv/bin/python -m pytest tests/unit/test_command_contract_validation.py tests/unit/test_check_prompt_quality.py -q`
- `./scripts/validate_prompts.sh`
