### PR TITLE
chore: consolidate canonical UX delegation policy source (#553)

### DIFF
--- a/.github/prompts/agents/README.md
+++ b/.github/prompts/agents/README.md
@@ -27,6 +27,11 @@ Do not use these files as generic end-user docs; they are operator rails for age
 - Delegate out-of-scope actions to the correct agent.
 - Keep detailed procedural content in shared modules under `../modules/`.
 
+## Canonical UX Delegation Policy
+
+- Canonical source: `.github/prompts/modules/ux/delegation-policy.md`
+- Agent/workflow prompts must reference this source instead of duplicating delegation policy blocks.
+
 ## Validation
 
 - `python scripts/check_prompt_quality.py`

--- a/.github/prompts/agents/continue-phase-2.md
+++ b/.github/prompts/agents/continue-phase-2.md
@@ -14,7 +14,7 @@
 1. Select next issue and validate dependencies.
 2. Create a small implementation slice (target reviewable diff and CI-safe scope).
 3. Run implementation via `scripts/work-issue.py` with existing guardrails.
-4. Ensure UX authority consultation evidence for UI-affecting changes.
+4. Apply UX delegation policy from `.github/prompts/modules/ux/delegation-policy.md`.
 5. Run validations and fix failures.
 6. Run PR review using repository rubric and confirm approval status.
 7. Merge via `scripts/prmerge` only after review + CI pass. If `prmerge` reports "No PR found" it is a complete answer (nothing to merge): do not prompt for a PR number; stop or move to next issue.
@@ -35,7 +35,7 @@ Default cap policy:
 
 - Keep one issue per PR.
 - Do not merge without review confirmation.
-- Preserve DDD boundaries and UX delegation policy.
+- Preserve DDD boundaries and canonical UX delegation policy.
 - Keep process deterministic and repeatable.
 
 **References:**

--- a/.github/prompts/agents/pr-merge.md
+++ b/.github/prompts/agents/pr-merge.md
@@ -25,7 +25,7 @@ Merge a ready PR safely, close the linked issue with traceability, and clean tem
 - Never fix PR content here; delegate to `resolve-issue-dev`.
 - Prefer `gh pr merge --squash --delete-branch`.
 - Use `.tmp/` (never `/tmp`) for transient files.
-- For UI/UX-affecting PRs, require evidence that `blecs-ux-authority` consultation passed.
+- Apply UX delegation policy from `../modules/ux/delegation-policy.md` (canonical source).
 
 ## Workflow
 

--- a/.github/prompts/agents/resolve-issue-dev.md
+++ b/.github/prompts/agents/resolve-issue-dev.md
@@ -29,7 +29,7 @@ Implement one issue into a small, reviewable PR with DDD-compliant changes and l
 - If Context7 is unavailable/offline, continue with local MCP-first grounding (`git`, `search`, `filesystem`, `bashGateway`) and repository docs (`docs/`, `README.md`, `templates/`).
 - Follow MCP Tool Arbitration Hard Rules from `modules/prompt-quality-baseline.md`; when tools overlap, the more specialized MCP server must win.
 - For internal architecture, prioritize repository conventions and local source-of-truth files.
-- If scope affects UI/UX/navigation/responsive behavior, consult `blecs-ux-authority` and block completion until `UX_DECISION: PASS`.
+- Apply UX delegation policy from `../modules/ux/delegation-policy.md` (canonical source).
 
 ## Workflow
 

--- a/.github/prompts/modules/continue-phase-2-workflow.md
+++ b/.github/prompts/modules/continue-phase-2-workflow.md
@@ -27,7 +27,7 @@ Merge rule:
 
 ## Quality Gates
 
-- Mandatory UX authority consultation for UI-affecting scope.
+- Apply canonical UX delegation policy from `./ux/delegation-policy.md`.
 - Mandatory PR review before merge.
 - CI must pass for merge path.
 - PR merge slice limits enforced by `scripts/prmerge` policy defaults.

--- a/.github/prompts/modules/resolve-issue-workflow.md
+++ b/.github/prompts/modules/resolve-issue-workflow.md
@@ -4,7 +4,7 @@
 
 1. Select issue (backend-first, lowest number) and confirm scope.
 2. Write compact plan: goal, scope, AC, files, validation commands.
-3. If scope affects UI/UX/navigation/responsive behavior, run `blecs-ux-authority` consultation and capture decision.
+3. Apply UX delegation policy from `./ux/delegation-policy.md` and capture required consultation outcome.
 4. Implement minimal code changes in a dedicated branch.
 5. Run required validations for touched areas.
 6. Commit with `Fixes #<issue>` and push.
@@ -22,4 +22,4 @@
 - Avoid unrelated refactors.
 - Keep diffs reviewable and DDD-compliant.
 - Use `.tmp/` for transient artifacts.
-- Block completion until UX consultation is `PASS` for UI-affecting scope.
+- Follow `./ux/delegation-policy.md` as the canonical delegation rule source.

--- a/.github/prompts/modules/ux/delegation-policy.md
+++ b/.github/prompts/modules/ux/delegation-policy.md
@@ -1,5 +1,7 @@
 # UX Skill: Delegation Policy (Mandatory)
 
+Canonical policy source: This file is the single source of truth for UX delegation rules across governance prompts and workflow prompts.
+
 - Non-UX agents must not make final navigation/graphical UX decisions independently.
 - If a change affects UI, navigation, responsive behavior, or visual grouping, consult `blecs-ux-authority`.
 - Block implementation/review completion until UX decision is `PASS` or required `CHANGES` are applied.


### PR DESCRIPTION
## Summary
- designates a single canonical UX delegation policy source
- replaces duplicated delegation wording in workflow/agent prompts with short canonical references
- updates governance prompt docs to declare the canonical source

## Issue
Fixes #553

## Canonical Source
- `.github/prompts/modules/ux/delegation-policy.md`

## Scope
- `.github/prompts/modules/ux/delegation-policy.md`
- `.github/prompts/agents/resolve-issue-dev.md`
- `.github/prompts/agents/pr-merge.md`
- `.github/prompts/agents/continue-phase-2.md`
- `.github/prompts/modules/resolve-issue-workflow.md`
- `.github/prompts/modules/continue-phase-2-workflow.md`
- `.github/prompts/agents/README.md`

## Validation
- `./scripts/validate_prompts.sh`
- `./.venv/bin/python -m pytest tests/unit/test_command_contract_validation.py tests/unit/test_check_prompt_quality.py tests/unit/test_check_continue_backend_policy.py tests/unit/test_check_prmerge_policy.py tests/unit/test_check_context7_guardrails.py -q`

## Contract Safety
- `UX_DECISION: PASS|CHANGES` output contract remains unchanged.
