### PR TITLE
test(#596): add deterministic selector policy matrix

### DIFF
--- a/docs/NEXT-ISSUE-COMMAND.md
+++ b/docs/NEXT-ISSUE-COMMAND.md
@@ -235,6 +235,16 @@ This helps set realistic expectations as the project progresses.
 5. **Context Enrichment** - Add local tracking details, learning insights, and adjusted estimates.
 6. **Display Recommendation** - Present the selected issue with GitHub-verified next steps.
 
+### Selector Test Matrix
+
+The selector tests in `tests/unit/test_next_issue.py` are deterministic and run without network access by stubbing GitHub responses.
+
+- Live-open ingestion beyond legacy ranges (`#595+` style issue numbers)
+- Priority ordering (High/CRITICAL before Medium/Low)
+- Number tie-break ordering (same priority → lowest issue number)
+- Blocker filtering (blocked issue skipped when ready issue exists)
+- All-blocked behavior (`None` selected when no ready issue exists)
+
 ## Key Features
 
 ### 1. Reconciliation-First Approach

--- a/tests/unit/test_next_issue.py
+++ b/tests/unit/test_next_issue.py
@@ -27,13 +27,30 @@ class _GitHubStub:
         return True
 
 
-def test_selector_uses_live_open_issues_beyond_legacy_range(tmp_path):
+class _GitHubBlockerStub(_GitHubStub):
+    def __init__(self, open_issues, resolved_issue_numbers):
+        super().__init__(open_issues)
+        self._resolved_issue_numbers = set(resolved_issue_numbers)
+
+    def is_issue_resolved(self, issue_number: int) -> bool:
+        return issue_number in self._resolved_issue_numbers
+
+
+def _create_selector(tmp_path, open_issues, tracking_text: str = "# empty", github=None):
     script_path = Path("scripts/next-issue.py").resolve()
-    mod = _load_module(script_path, "next_issue_script")
+    mod = _load_module(script_path, f"next_issue_script_{id(open_issues)}")
 
     tracking_file = tmp_path / "tracking.md"
-    tracking_file.write_text("# empty", encoding="utf-8")
+    tracking_file.write_text(tracking_text, encoding="utf-8")
 
+    if github is None:
+        github = _GitHubStub(open_issues)
+
+    selector = mod.IssueSelector(tracking_file, _KnowledgeStub(), github)
+    return selector
+
+
+def test_selector_uses_live_open_issues_beyond_legacy_range(tmp_path):
     open_issues = [
         {
             "number": 595,
@@ -44,19 +61,13 @@ def test_selector_uses_live_open_issues_beyond_legacy_range(tmp_path):
         }
     ]
 
-    selector = mod.IssueSelector(tracking_file, _KnowledgeStub(), _GitHubStub(open_issues))
+    selector = _create_selector(tmp_path, open_issues)
     assert len(selector.issues) == 1
     assert selector.issues[0]["number"] == 595
     assert selector.issues[0]["state"] == "Open"
 
 
 def test_selector_orders_live_open_issues_by_priority_then_number(tmp_path):
-    script_path = Path("scripts/next-issue.py").resolve()
-    mod = _load_module(script_path, "next_issue_script_order")
-
-    tracking_file = tmp_path / "tracking.md"
-    tracking_file.write_text("# empty", encoding="utf-8")
-
     open_issues = [
         {
             "number": 596,
@@ -74,8 +85,116 @@ def test_selector_orders_live_open_issues_by_priority_then_number(tmp_path):
         },
     ]
 
-    selector = mod.IssueSelector(tracking_file, _KnowledgeStub(), _GitHubStub(open_issues))
+    selector = _create_selector(tmp_path, open_issues)
     selected = selector.select_next_issue()
 
     assert selected is not None
-    assert selected["number"] == 595
+    assert selected["number"] == 595, (
+        "policy violation: with equal priority, selector must choose lowest issue number"
+    )
+
+
+def test_selector_skips_blocked_issue_and_selects_next_ready(tmp_path):
+    open_issues = [
+        {
+            "number": 30,
+            "title": "Blocked by #595",
+            "state": "OPEN",
+            "labels": [],
+            "closedAt": None,
+        },
+        {
+            "number": 31,
+            "title": "Ready issue",
+            "state": "OPEN",
+            "labels": [],
+            "closedAt": None,
+        },
+    ]
+    tracking_text = """### Issue #30: blocked
+Blockers: #24
+Estimated: 4.0
+
+### Issue #31: ready
+Blockers: none
+Estimated: 4.0
+"""
+
+    github = _GitHubBlockerStub(open_issues, resolved_issue_numbers=set())
+    selector = _create_selector(tmp_path, open_issues, tracking_text=tracking_text, github=github)
+    selected = selector.select_next_issue()
+
+    assert selected is not None
+    assert selected["number"] == 31, (
+        "policy violation: blocked issues must not be selected when a ready issue exists"
+    )
+
+
+def test_selector_returns_none_when_all_open_issues_are_blocked(tmp_path):
+    open_issues = [
+        {
+            "number": 30,
+            "title": "Blocked A",
+            "state": "OPEN",
+            "labels": [],
+            "closedAt": None,
+        },
+        {
+            "number": 31,
+            "title": "Blocked B",
+            "state": "OPEN",
+            "labels": [],
+            "closedAt": None,
+        },
+    ]
+    tracking_text = """### Issue #30: blocked
+Blockers: #24
+Estimated: 4.0
+
+### Issue #31: blocked
+Blockers: #25
+Estimated: 4.0
+"""
+
+    github = _GitHubBlockerStub(open_issues, resolved_issue_numbers=set())
+    selector = _create_selector(tmp_path, open_issues, tracking_text=tracking_text, github=github)
+    selected = selector.select_next_issue()
+
+    assert selected is None, "policy violation: selector must return None when every open issue is blocked"
+
+
+def test_selector_prefers_higher_priority_over_lower_issue_number(tmp_path):
+    open_issues = [
+        {
+            "number": 24,
+            "title": "Low-number medium issue",
+            "state": "OPEN",
+            "labels": [],
+            "closedAt": None,
+        },
+        {
+            "number": 29,
+            "title": "High-priority issue",
+            "state": "OPEN",
+            "labels": [],
+            "closedAt": None,
+        },
+    ]
+    tracking_text = """### Issue #24: medium
+Priority: Medium
+Blockers: none
+Estimated: 4.0
+
+### Issue #29: high
+Priority: High
+Blockers: none
+Estimated: 4.0
+"""
+
+    selector = _create_selector(tmp_path, open_issues, tracking_text=tracking_text)
+    selected = selector.select_next_issue()
+
+    assert selected is not None
+    assert selected["number"] == 29, (
+        "policy violation: selector must prioritize High over Medium regardless of issue number"
+    )


### PR DESCRIPTION
## Goal / Context
- Add deterministic, offline selector tests that cover ordering and blocker policies to prevent regressions.
- Provide explicit assertion messages that identify policy deviations quickly.
- Document the selector test matrix in command docs for maintainers.

## Acceptance Criteria
- [x] Added at least three deterministic mixed-scenario selector tests (ordering, blocker skip, all-blocked, priority tie-break).
- [x] Tests run without network by stubbing GitHub interactions.
- [x] Added a selector test matrix section to docs.

## Validation Evidence
- `./.venv/bin/python -m pytest tests/unit/test_next_issue.py -q` → `5 passed`
- `./.venv/bin/python -m pytest tests/integration -k "workflow or issue" -q` → `26 passed`
- `./.venv/bin/python -m pytest tests/unit -k "next_issue" -q` → fails during unrelated collection (`tests/unit/test_audit_service.py` import path issue)

## Repo Hygiene / Safety
- Scope limited to `tests/unit/test_next_issue.py` and `docs/NEXT-ISSUE-COMMAND.md`.
- No runtime behavior changes in selector logic.
- No dependency changes.

Fixes: #596
