### PR TITLE
chore: remove autonomous issue task entry from VS Code tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -21,20 +21,6 @@
       }
     },
     {
-      "label": "🤖 Work on Issue (Autonomous)",
-      "type": "shell",
-      "command": "${workspaceFolder}/scripts/work-issue.py",
-      "args": ["--issue", "${input:issueNumber}"],
-      "problemMatcher": [],
-      "presentation": {
-        "reveal": "always",
-        "panel": "dedicated",
-        "focus": true,
-        "clear": true
-      },
-      "group": "none"
-    },
-    {
       "label": "🔍 Work on Issue (Dry Run)",
       "type": "shell",
       "command": "${workspaceFolder}/scripts/work-issue.py",


### PR DESCRIPTION
## Summary
- remove the  task from 
- keep remaining issue workflow tasks unchanged

## Validation
- reviewed  for 
