### PR TITLE
fix(mcp): run offline-docs as host user

### DIFF
--- a/docker-compose.mcp-offline-docs.yml
+++ b/docker-compose.mcp-offline-docs.yml
@@ -6,6 +6,7 @@ services:
       context: .
       dockerfile: docker/mcp-offline-docs/Dockerfile
     container_name: offline-docs-mcp
+    user: "${OFFLINE_DOCS_UID:-1000}:${OFFLINE_DOCS_GID:-1000}"
     restart: unless-stopped
     environment:
       - OFFLINE_DOCS_MCP_PORT=3017

--- a/docs/howto/mcp-offline-docs.md
+++ b/docs/howto/mcp-offline-docs.md
@@ -8,7 +8,14 @@ by indexing local repository docs into a SQLite full-text index.
 ## Start with Docker Compose
 
 ```bash
+OFFLINE_DOCS_UID=$(id -u) OFFLINE_DOCS_GID=$(id -g) \
 docker compose -f docker-compose.mcp-offline-docs.yml up -d --build
+```
+
+If you previously ran the service as `root`, you may need a one-time cleanup so the container can write the DB as your user:
+
+```bash
+sudo rm -rf .tmp/mcp-offline-docs
 ```
 
 ## Endpoint check

--- a/scripts/install-offline-docs-mcp-systemd.sh
+++ b/scripts/install-offline-docs-mcp-systemd.sh
@@ -44,6 +44,9 @@ fi
 if [[ ! -f "${ENV_FILE}" ]]; then
   sudo tee "${ENV_FILE}" >/dev/null <<'EOF'
 # Optional overrides for Offline Docs MCP service
+# Run the container as a specific numeric UID/GID to avoid root-owned files in the bind-mounted workspace.
+# OFFLINE_DOCS_UID=1000
+# OFFLINE_DOCS_GID=1000
 # OFFLINE_DOCS_INDEX_SOURCES=docs,README.md,QUICKSTART.md,templates
 # OFFLINE_DOCS_INDEX_DB=/workspace/.tmp/mcp-offline-docs/docs_index.db
 EOF


### PR DESCRIPTION
## Goal / Context

- Links: Fixes #636
- Related client repo (if relevant): N/A
- Scope (what’s included / excluded):
  - Included: run Offline Docs MCP container as host UID/GID (configurable), update docs + systemd env template
  - Excluded: changes to MCP server behavior, indexing logic, or API

## Acceptance Criteria (copy from the issue)

- [x] Offline Docs MCP index DB can be created/cleaned without root-owned files in the bind-mounted workspace
- [x] Docker Compose usage documents setting UID/GID env vars
- [x] systemd env template documents UID/GID overrides

## Implementation Notes

- Key design choices:
  - Compose uses `user: "${OFFLINE_DOCS_UID:-1000}:${OFFLINE_DOCS_GID:-1000}"` to avoid writing as root.
- API changes (endpoints/contracts): no
- Cross-repo impact: none

## Validation Evidence

Backend:

- [x] `bash -n scripts/install-offline-docs-mcp-systemd.sh`
- [x] `docker compose -f docker-compose.mcp-offline-docs.yml config`

## Repo Hygiene / Safety

- [x] `projectDocs/` is NOT committed
- [x] `configs/llm.json` is NOT committed
- [x] No secrets in code/logs
