### PR TITLE
fix: align gh throttling across workflow scripts

### DIFF
--- a/agents/base_agent.py
+++ b/agents/base_agent.py
@@ -13,6 +13,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 
+from agents.tooling.gh_throttle import run_gh_throttled
+
 
 class BaseAgent(ABC):
     """Base class for all custom AI agents."""
@@ -186,7 +188,12 @@ class BaseAgent(ABC):
 
         # Check GitHub CLI
         try:
-            subprocess.run(["gh", "--version"], capture_output=True, check=True)
+            run_gh_throttled(
+                ["gh", "--version"],
+                capture_output=True,
+                check=True,
+                min_interval_seconds=0,
+            )
         except (subprocess.CalledProcessError, FileNotFoundError):
             self.log("GitHub CLI (gh) not installed", "error")
             return False

--- a/scripts/next-issue.py
+++ b/scripts/next-issue.py
@@ -39,6 +39,10 @@ from typing import Dict, List, Optional, Tuple
 
 # Repository root
 REPO_ROOT = Path(__file__).parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from agents.tooling.gh_throttle import run_gh_throttled
 
 
 def _resolve_step1_file(primary: Path, fallback: Path) -> Path:
@@ -395,11 +399,12 @@ class GitHubClient:
 
             self._throttle_request()
             
-            result = subprocess.run(
+            result = run_gh_throttled(
                 cmd,
                 capture_output=True,
                 text=True,
-                timeout=timeout
+                timeout=timeout,
+                min_interval_seconds=0,
             )
             
             if result.returncode == 0 and result.stdout.strip():
@@ -886,7 +891,13 @@ def _main_impl(args):
     """Main implementation (separated for timeout handling)"""
     # Check if gh CLI is available
     try:
-        subprocess.run(["gh", "--version"], capture_output=True, check=True, timeout=5)
+        run_gh_throttled(
+            ["gh", "--version"],
+            capture_output=True,
+            check=True,
+            timeout=5,
+            min_interval_seconds=0,
+        )
     except (FileNotFoundError, subprocess.CalledProcessError):
         print("❌ Error: 'gh' CLI not found or not authenticated.")
         print("\nInstall: https://cli.github.com/")

--- a/scripts/publish_issues.py
+++ b/scripts/publish_issues.py
@@ -16,6 +16,11 @@ from typing import Any, Callable
 import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from agents.tooling.gh_throttle import run_gh_throttled
+
 DEFAULT_GLOB = "planning/issues/*.yml"
 DEFAULT_MAP_PATH = ROOT / "planning/issues/.published-map.json"
 DEFAULT_SLEEP_SECONDS = 1.0
@@ -68,7 +73,7 @@ class IssueSpec:
 
 def _run_gh_json(args: list[str]) -> Any:
     _throttle_gh()
-    proc = subprocess.run(["gh", *args], capture_output=True, text=True)
+    proc = run_gh_throttled(["gh", *args], capture_output=True, text=True, min_interval_seconds=0)
     if proc.returncode != 0:
         raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or f"gh {' '.join(args)} failed")
     return json.loads(proc.stdout)
@@ -76,7 +81,7 @@ def _run_gh_json(args: list[str]) -> Any:
 
 def _run_gh_text(args: list[str]) -> str:
     _throttle_gh()
-    proc = subprocess.run(["gh", *args], capture_output=True, text=True)
+    proc = run_gh_throttled(["gh", *args], capture_output=True, text=True, min_interval_seconds=0)
     if proc.returncode != 0:
         raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or f"gh {' '.join(args)} failed")
     return proc.stdout.strip()


### PR DESCRIPTION
## Summary
- route remaining direct gh CLI calls through shared \ helper
- keep script-specific pacing in publish flow while adding shared rate-limit retry behavior
- apply consistent throttled gh availability checks in base agent and next-issue workflow

## Files
- agents/base_agent.py
- scripts/next-issue.py
- scripts/publish_issues.py

## Validation
- .venv/bin/python -m pytest tests/unit/test_gh_throttle.py -q
- runTests: tests/unit/test_gh_throttle.py, tests/agents/test_tools_modular_typed.py (14 passed)

Closes #628