### PR TITLE
chore(tasks): enforce workflow model config for work-issue tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -24,7 +24,13 @@
       "label": "🔍 Work on Issue (Dry Run)",
       "type": "shell",
       "command": "${workspaceFolder}/scripts/work-issue.py",
-      "args": ["--issue", "${input:issueNumber}", "--dry-run"],
+      "args": [
+        "--issue",
+        "${input:issueNumber}",
+        "--dry-run",
+        "--llm-config",
+        "configs/llm.workflow.json"
+      ],
       "problemMatcher": [],
       "presentation": {
         "reveal": "always",
@@ -38,7 +44,13 @@
       "label": "💬 Work on Issue (Interactive)",
       "type": "shell",
       "command": "${workspaceFolder}/scripts/work-issue.py",
-      "args": ["--issue", "${input:issueNumber}", "--interactive"],
+      "args": [
+        "--issue",
+        "${input:issueNumber}",
+        "--interactive",
+        "--llm-config",
+        "configs/llm.workflow.json"
+      ],
       "problemMatcher": [],
       "presentation": {
         "reveal": "always",


### PR DESCRIPTION
## Summary
- enforce `--llm-config configs/llm.workflow.json` in VS Code ad-hoc work tasks
- align dry-run and interactive task behavior with role-split model policy

## Validation
- JSON task file checked in editor diagnostics

Fixes #647
