### PR TITLE
fix(workflow): non-interactive loops and bounded 429 retries

### DIFF
--- a/agents/autonomous_workflow_agent.py
+++ b/agents/autonomous_workflow_agent.py
@@ -32,6 +32,11 @@ from agent_framework.openai import OpenAIChatClient
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from agents.tooling.gh_throttle import run_gh_throttled
+from agents.tooling.api_throttle import (
+    apply_rate_limit_penalty,
+    extract_retry_after_seconds,
+    reserve_api_slot,
+)
 
 from agents.llm_client import LLMClientFactory
 from agents.tools import get_all_tools, get_shell_only_tools
@@ -1537,12 +1542,39 @@ Begin now."""
         if not self.agent or not self.thread:
             raise RuntimeError("Agent not initialized or no active thread")
 
-        response_text = []
-        async for chunk in self.agent.run_stream(message, thread=self.thread):
-            if chunk.text:
-                response_text.append(chunk.text)
+        max_rate_limit_retries = int(
+            os.environ.get("WORK_ISSUE_RATE_LIMIT_MAX_RETRIES", "6")
+        )
+        attempt = 0
 
-        return "".join(response_text)
+        while True:
+            attempt += 1
+            throttle_wait = reserve_api_slot("llm")
+            if throttle_wait > 0:
+                await asyncio.sleep(throttle_wait)
+
+            response_text: list[str] = []
+            try:
+                async for chunk in self.agent.run_stream(message, thread=self.thread):
+                    if chunk.text:
+                        response_text.append(chunk.text)
+                return "".join(response_text)
+            except Exception as exc:
+                text = str(exc)
+                lowered = text.lower()
+                is_rate_limit = any(
+                    token in lowered
+                    for token in ("rate limit", "ratelimit", "too many requests", "429")
+                )
+                if is_rate_limit:
+                    retry_after = extract_retry_after_seconds(text)
+                    cooldown = apply_rate_limit_penalty("llm", retry_after)
+                    if not response_text and attempt <= max_rate_limit_retries:
+                        wait_seconds = reserve_api_slot("llm")
+                        wait_seconds = max(wait_seconds, cooldown)
+                        await asyncio.sleep(wait_seconds)
+                        continue
+                raise
 
     async def _extract_and_update_learnings(self, execution_data: dict):
         """

--- a/agents/tooling/api_throttle.py
+++ b/agents/tooling/api_throttle.py
@@ -1,0 +1,205 @@
+import json
+import os
+import random
+import re
+import time
+from pathlib import Path
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover
+    fcntl = None
+
+
+def _parse_float_env(name: str, default: float) -> float:
+    raw = (os.environ.get(name) or "").strip()
+    try:
+        return float(raw)
+    except ValueError:
+        return default
+
+
+def _clamp(value: float, min_value: float, max_value: float) -> float:
+    return max(min_value, min(max_value, value))
+
+
+def _resolve_max_rps() -> float:
+    value = _parse_float_env("WORK_ISSUE_MAX_RPS", 0.10)
+    return max(0.0, value)
+
+
+def _resolve_jitter_ratio() -> float:
+    value = _parse_float_env("WORK_ISSUE_RPS_JITTER", 0.25)
+    return _clamp(value, 0.0, 1.0)
+
+
+def _resolve_max_wait_seconds() -> float:
+    value = _parse_float_env("WORK_ISSUE_MAX_THROTTLE_WAIT_SECONDS", 180.0)
+    return max(1.0, value)
+
+
+def _resolve_rate_limit_cooldown_seconds() -> float:
+    value = _parse_float_env("WORK_ISSUE_RATE_LIMIT_COOLDOWN_SECONDS", 45.0)
+    return max(1.0, value)
+
+
+def _state_path() -> Path:
+    configured = (os.environ.get("WORK_ISSUE_API_THROTTLE_STATE_FILE") or "").strip()
+    if configured:
+        path = Path(configured)
+    else:
+        path = Path(".tmp") / "api-throttle-state.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _lock_path() -> Path:
+    configured = (os.environ.get("WORK_ISSUE_API_THROTTLE_LOCK_FILE") or "").strip()
+    if configured:
+        path = Path(configured)
+    else:
+        path = Path(".tmp") / "api-throttle.lock"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _load_state(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _save_state(path: Path, state: dict) -> None:
+    temp_path = path.with_suffix(path.suffix + ".tmp")
+    temp_path.write_text(json.dumps(state), encoding="utf-8")
+    temp_path.replace(path)
+
+
+def reserve_api_slot(channel: str = "llm") -> float:
+    """Reserve the next outbound API slot across parallel processes.
+
+    Returns the number of seconds the caller should wait before making
+    the next API call.
+    """
+
+    max_rps = _resolve_max_rps()
+    if max_rps <= 0:
+        return 0.0
+
+    min_interval = 1.0 / max_rps
+    jitter_ratio = _resolve_jitter_ratio()
+    max_wait_seconds = _resolve_max_wait_seconds()
+
+    state_path = _state_path()
+    lock_path = _lock_path()
+
+    if fcntl is None:
+        return 0.0
+
+    now = time.time()
+    with lock_path.open("a+", encoding="utf-8") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        state = _load_state(state_path)
+        channels = state.get("channels")
+        if not isinstance(channels, dict):
+            channels = {}
+
+        channel_state = channels.get(channel)
+        if not isinstance(channel_state, dict):
+            channel_state = {}
+
+        next_allowed_ts = channel_state.get("next_allowed_ts", 0.0)
+        try:
+            next_allowed_ts = float(next_allowed_ts)
+        except (TypeError, ValueError):
+            next_allowed_ts = 0.0
+
+        base_wait = max(0.0, next_allowed_ts - now)
+        jitter_wait = random.uniform(0.0, min_interval * jitter_ratio)
+        total_wait = min(max_wait_seconds, base_wait + jitter_wait)
+
+        reserved_at = now + total_wait
+        channel_state["next_allowed_ts"] = reserved_at + min_interval
+        channel_state["updated_at"] = now
+        channels[channel] = channel_state
+        state["channels"] = channels
+        _save_state(state_path, state)
+
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+    return total_wait
+
+
+def extract_retry_after_seconds(text: str) -> float | None:
+    if not text:
+        return None
+
+    retry_after = re.search(r"retry[- ]after[^0-9]*(\d+)", text, flags=re.IGNORECASE)
+    if retry_after:
+        try:
+            return float(retry_after.group(1))
+        except ValueError:
+            return None
+
+    try_again = re.search(
+        r"try again in\s+(?:(\d+)m)?\s*(?:(\d+)s)?",
+        text,
+        flags=re.IGNORECASE,
+    )
+    if try_again:
+        minutes = int(try_again.group(1) or "0")
+        seconds = int(try_again.group(2) or "0")
+        total = (minutes * 60) + seconds
+        if total > 0:
+            return float(total)
+
+    return None
+
+
+def apply_rate_limit_penalty(channel: str = "llm", penalty_seconds: float | None = None) -> float:
+    """Set a shared cooldown window after rate-limit responses.
+
+    Returns the applied cooldown seconds.
+    """
+    cooldown = (
+        penalty_seconds
+        if penalty_seconds is not None and penalty_seconds > 0
+        else _resolve_rate_limit_cooldown_seconds()
+    )
+
+    state_path = _state_path()
+    lock_path = _lock_path()
+
+    if fcntl is None:
+        return cooldown
+
+    now = time.time()
+    with lock_path.open("a+", encoding="utf-8") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        state = _load_state(state_path)
+        channels = state.get("channels")
+        if not isinstance(channels, dict):
+            channels = {}
+
+        channel_state = channels.get(channel)
+        if not isinstance(channel_state, dict):
+            channel_state = {}
+
+        next_allowed_ts = channel_state.get("next_allowed_ts", 0.0)
+        try:
+            next_allowed_ts = float(next_allowed_ts)
+        except (TypeError, ValueError):
+            next_allowed_ts = 0.0
+
+        channel_state["next_allowed_ts"] = max(next_allowed_ts, now + cooldown)
+        channel_state["updated_at"] = now
+        channels[channel] = channel_state
+        state["channels"] = channels
+        _save_state(state_path, state)
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+    return cooldown

--- a/scripts/continue-backend.sh
+++ b/scripts/continue-backend.sh
@@ -159,9 +159,17 @@ fi
 
 if [[ "$MAX_ISSUES" -gt "$MAX_ISSUES_CAP" ]]; then
   echo "Requested --max-issues=$MAX_ISSUES exceeds hard baseline ($MAX_ISSUES_CAP)."
-  read -r -p "Override baseline and continue with $MAX_ISSUES issues? (y/N): " override_cap
-  if [[ ! "$override_cap" =~ ^[Yy]$ ]]; then
-    echo "Cancelled. Re-run with --max-issues $MAX_ISSUES_CAP or confirm override."
+  if [[ "${CONTINUE_PHASE_ASSUME_YES:-}" == "1" ]]; then
+    echo "CONTINUE_PHASE_ASSUME_YES=1: overriding baseline without prompt."
+  elif [[ -t 0 ]]; then
+    read -r -p "Override baseline and continue with $MAX_ISSUES issues? (y/N): " override_cap
+    if [[ ! "$override_cap" =~ ^[Yy]$ ]]; then
+      echo "Cancelled. Re-run with --max-issues $MAX_ISSUES_CAP or confirm override."
+      exit 1
+    fi
+  else
+    echo "Non-interactive stdin; cannot prompt for override confirmation." >&2
+    echo "Re-run with --max-issues $MAX_ISSUES_CAP, or set CONTINUE_PHASE_ASSUME_YES=1 to override." >&2
     exit 1
   fi
 fi
@@ -510,7 +518,7 @@ while true; do
 
   if [[ "$DRY_RUN" == "1" ]]; then
     echo "[dry-run] Would run: ./scripts/work-issue.py --issue $issue --create-split-issues"
-    echo "[dry-run] Would run: ./scripts/prmerge $issue"
+    echo "[dry-run] Would run: PRMERGE_ASSUME_YES=1 ./scripts/prmerge $issue"
   else
     set +e
     run_work_issue_with_retry "$issue"
@@ -525,7 +533,7 @@ while true; do
       exit "$work_rc"
     fi
 
-    ./scripts/prmerge "$issue"
+    PRMERGE_ASSUME_YES=1 ./scripts/prmerge "$issue"
   fi
 
   count=$((count + 1))

--- a/scripts/continue-phase-2.sh
+++ b/scripts/continue-phase-2.sh
@@ -68,9 +68,17 @@ fi
 
 if [[ "$MAX_ISSUES" -gt "$MAX_ISSUES_CAP" ]]; then
   echo "Requested --max-issues=$MAX_ISSUES exceeds default cap ($MAX_ISSUES_CAP)."
-  read -r -p "Override cap and continue? (y/N): " override_cap
-  if [[ ! "$override_cap" =~ ^[Yy]$ ]]; then
-    echo "Cancelled. Re-run with --max-issues <= $MAX_ISSUES_CAP or confirm override."
+  if [[ "${CONTINUE_PHASE_ASSUME_YES:-}" == "1" ]]; then
+    echo "CONTINUE_PHASE_ASSUME_YES=1: overriding baseline without prompt."
+  elif [[ -t 0 ]]; then
+    read -r -p "Override cap and continue? (y/N): " override_cap
+    if [[ ! "$override_cap" =~ ^[Yy]$ ]]; then
+      echo "Cancelled. Re-run with --max-issues <= $MAX_ISSUES_CAP or confirm override."
+      exit 1
+    fi
+  else
+    echo "Non-interactive stdin; cannot prompt for override confirmation." >&2
+    echo "Re-run with --max-issues <= $MAX_ISSUES_CAP, or set CONTINUE_PHASE_ASSUME_YES=1 to override." >&2
     exit 1
   fi
 fi
@@ -119,10 +127,10 @@ while true; do
 
   if [[ "$DRY_RUN" == "1" ]]; then
     echo "[dry-run] Would run: ./scripts/work-issue.py --issue $issue"
-    echo "[dry-run] Would run: ./scripts/prmerge $issue"
+    echo "[dry-run] Would run: PRMERGE_ASSUME_YES=1 ./scripts/prmerge $issue"
   else
     ./scripts/work-issue.py --issue "$issue"
-    ./scripts/prmerge "$issue"
+    PRMERGE_ASSUME_YES=1 ./scripts/prmerge "$issue"
   fi
 
   count=$((count + 1))

--- a/scripts/continue-phase-3.sh
+++ b/scripts/continue-phase-3.sh
@@ -121,9 +121,17 @@ fi
 
 if [[ "$MAX_ISSUES" -gt "$MAX_ISSUES_CAP" ]]; then
   echo "Requested --max-issues=$MAX_ISSUES exceeds hard baseline ($MAX_ISSUES_CAP)."
-  read -r -p "Override baseline and continue with $MAX_ISSUES issues? (y/N): " override_cap
-  if [[ ! "$override_cap" =~ ^[Yy]$ ]]; then
-    echo "Cancelled. Re-run with --max-issues $MAX_ISSUES_CAP or confirm override."
+  if [[ "${CONTINUE_PHASE_ASSUME_YES:-}" == "1" ]]; then
+    echo "CONTINUE_PHASE_ASSUME_YES=1: overriding baseline without prompt."
+  elif [[ -t 0 ]]; then
+    read -r -p "Override baseline and continue with $MAX_ISSUES issues? (y/N): " override_cap
+    if [[ ! "$override_cap" =~ ^[Yy]$ ]]; then
+      echo "Cancelled. Re-run with --max-issues $MAX_ISSUES_CAP or confirm override."
+      exit 1
+    fi
+  else
+    echo "Non-interactive stdin; cannot prompt for override confirmation." >&2
+    echo "Re-run with --max-issues $MAX_ISSUES_CAP, or set CONTINUE_PHASE_ASSUME_YES=1 to override." >&2
     exit 1
   fi
 fi
@@ -237,7 +245,7 @@ while true; do
 
   if [[ "$DRY_RUN" == "1" ]]; then
     echo "[dry-run] Would run: ./scripts/work-issue.py --issue $issue"
-    echo "[dry-run] Would run: ./scripts/prmerge $issue"
+    echo "[dry-run] Would run: PRMERGE_ASSUME_YES=1 ./scripts/prmerge $issue"
   else
     set +e
     ./scripts/work-issue.py --issue "$issue" --create-split-issues
@@ -261,7 +269,7 @@ while true; do
       exit "$work_rc"
     fi
 
-    ./scripts/prmerge "$issue"
+    PRMERGE_ASSUME_YES=1 ./scripts/prmerge "$issue"
   fi
 
   count=$((count + 1))

--- a/scripts/work-issue.py
+++ b/scripts/work-issue.py
@@ -172,6 +172,9 @@ Token Budget Mode:
     os.environ.setdefault("WORK_ISSUE_PLANNING_FALLBACK_AFTER_ATTEMPT", "3")
     os.environ.setdefault("WORK_ISSUE_PLANNING_FALLBACK_MAX_ATTEMPTS", "6")
     os.environ.setdefault("WORK_ISSUE_PLANNING_FALLBACK_PROMPT_CHARS", "1400")
+    os.environ.setdefault("WORK_ISSUE_MAX_RPS", "0.03")
+    os.environ.setdefault("WORK_ISSUE_RPS_JITTER", "0.25")
+    os.environ.setdefault("WORK_ISSUE_RATE_LIMIT_COOLDOWN_SECONDS", "120")
 
     archive_enabled = (
         not args.no_goal_archive


### PR DESCRIPTION
## Summary
- retry/sleep on LLM 429 rate-limits in autonomous streaming calls instead of immediate abort
- prevent non-interactive loop runs from hanging on stdin prompts
- invoke `prmerge` non-interactively inside continue loops

## Validation
- `🧪 Dev Stack: Smoke Test` task: PASS
- `printf '' | ./scripts/continue-phase-3.sh --max-issues 99 --dry-run` now fails fast with explicit non-interactive guidance (no hang)
- `CONTINUE_PHASE_ASSUME_YES=1 ./scripts/continue-phase-3.sh --max-issues 26 --dry-run` shows `PRMERGE_ASSUME_YES=1 ./scripts/prmerge ...`

Fixes #678
