### PR TITLE
chore(step3): recreate smaller tagged backlog and loop guard

### DIFF
--- a/planning/issues/.published-map.json
+++ b/planning/issues/.published-map.json
@@ -33,6 +33,50 @@
       "title": "Phase 3 \u2014 Align client UX evidence checks with requirement-gap contract",
       "title_hash": "c73a2c960d5f"
     },
+    "blecx/AI-Agent-Framework-Client|S3R-UX-01": {
+      "issue_number": 267,
+      "issue_url": "https://github.com/blecx/AI-Agent-Framework-Client/issues/267",
+      "repo": "blecx/AI-Agent-Framework-Client",
+      "repo_alias": "AI-Agent-Framework-Client",
+      "source_file": "planning/issues/step-3.yml",
+      "source_id": "S3R-UX-01",
+      "status": "created",
+      "title": "Step 3R \u2014 Client E2E deterministic fixture baseline",
+      "title_hash": "165d0c6cbe60"
+    },
+    "blecx/AI-Agent-Framework-Client|S3R-UX-02": {
+      "issue_number": 268,
+      "issue_url": "https://github.com/blecx/AI-Agent-Framework-Client/issues/268",
+      "repo": "blecx/AI-Agent-Framework-Client",
+      "repo_alias": "AI-Agent-Framework-Client",
+      "source_file": "planning/issues/step-3.yml",
+      "source_id": "S3R-UX-02",
+      "status": "created",
+      "title": "Step 3R \u2014 Client form validation consistency pass",
+      "title_hash": "de11c2f78bcb"
+    },
+    "blecx/AI-Agent-Framework-Client|S3R-UX-03": {
+      "issue_number": 269,
+      "issue_url": "https://github.com/blecx/AI-Agent-Framework-Client/issues/269",
+      "repo": "blecx/AI-Agent-Framework-Client",
+      "repo_alias": "AI-Agent-Framework-Client",
+      "source_file": "planning/issues/step-3.yml",
+      "source_id": "S3R-UX-03",
+      "status": "created",
+      "title": "Step 3R \u2014 Client API error fallback consistency",
+      "title_hash": "329279b17186"
+    },
+    "blecx/AI-Agent-Framework-Client|S3R-UX-04": {
+      "issue_number": 270,
+      "issue_url": "https://github.com/blecx/AI-Agent-Framework-Client/issues/270",
+      "repo": "blecx/AI-Agent-Framework-Client",
+      "repo_alias": "AI-Agent-Framework-Client",
+      "source_file": "planning/issues/step-3.yml",
+      "source_id": "S3R-UX-04",
+      "status": "created",
+      "title": "Step 3R \u2014 Client test-doc freshness CI check",
+      "title_hash": "984ac1c131ac"
+    },
     "blecx/AI-Agent-Framework|P2-BE-01": {
       "issue_number": 375,
       "issue_url": "https://github.com/blecx/AI-Agent-Framework/issues/375",
@@ -109,6 +153,105 @@
       "status": "created",
       "title": "Phase 3 \u2014 Align prompt modules and workflow docs to single UX authority contract",
       "title_hash": "54289fec2534"
+    },
+    "blecx/AI-Agent-Framework|S3R-BE-01": {
+      "issue_number": 680,
+      "issue_url": "https://github.com/blecx/AI-Agent-Framework/issues/680",
+      "repo": "blecx/AI-Agent-Framework",
+      "repo_alias": "AI-Agent-Framework",
+      "source_file": "planning/issues/step-3.yml",
+      "source_id": "S3R-BE-01",
+      "status": "created",
+      "title": "Step 3R \u2014 Establish deterministic TUI E2E fixture baseline",
+      "title_hash": "252e51408ba5"
+    },
+    "blecx/AI-Agent-Framework|S3R-BE-02": {
+      "issue_number": 681,
+      "issue_url": "https://github.com/blecx/AI-Agent-Framework/issues/681",
+      "repo": "blecx/AI-Agent-Framework",
+      "repo_alias": "AI-Agent-Framework",
+      "source_file": "planning/issues/step-3.yml",
+      "source_id": "S3R-BE-02",
+      "status": "created",
+      "title": "Step 3R \u2014 TUI E2E spine scenario stabilization",
+      "title_hash": "7168959fa962"
+    },
+    "blecx/AI-Agent-Framework|S3R-BE-03": {
+      "issue_number": 682,
+      "issue_url": "https://github.com/blecx/AI-Agent-Framework/issues/682",
+      "repo": "blecx/AI-Agent-Framework",
+      "repo_alias": "AI-Agent-Framework",
+      "source_file": "planning/issues/step-3.yml",
+      "source_id": "S3R-BE-03",
+      "status": "created",
+      "title": "Step 3R \u2014 Proposal apply/review E2E stabilization",
+      "title_hash": "466bc0e83bc5"
+    },
+    "blecx/AI-Agent-Framework|S3R-BE-04": {
+      "issue_number": 683,
+      "issue_url": "https://github.com/blecx/AI-Agent-Framework/issues/683",
+      "repo": "blecx/AI-Agent-Framework",
+      "repo_alias": "AI-Agent-Framework",
+      "source_file": "planning/issues/step-3.yml",
+      "source_id": "S3R-BE-04",
+      "status": "created",
+      "title": "Step 3R \u2014 Audit fix-cycle E2E stabilization",
+      "title_hash": "dd0bdcc7e8b6"
+    },
+    "blecx/AI-Agent-Framework|S3R-BE-05": {
+      "issue_number": 684,
+      "issue_url": "https://github.com/blecx/AI-Agent-Framework/issues/684",
+      "repo": "blecx/AI-Agent-Framework",
+      "repo_alias": "AI-Agent-Framework",
+      "source_file": "planning/issues/step-3.yml",
+      "source_id": "S3R-BE-05",
+      "status": "created",
+      "title": "Step 3R \u2014 Audit rule: cross-reference consistency",
+      "title_hash": "3357ca10f837"
+    },
+    "blecx/AI-Agent-Framework|S3R-BE-06": {
+      "issue_number": 685,
+      "issue_url": "https://github.com/blecx/AI-Agent-Framework/issues/685",
+      "repo": "blecx/AI-Agent-Framework",
+      "repo_alias": "AI-Agent-Framework",
+      "source_file": "planning/issues/step-3.yml",
+      "source_id": "S3R-BE-06",
+      "status": "created",
+      "title": "Step 3R \u2014 Audit rule: date-window consistency",
+      "title_hash": "fc743c9f1a84"
+    },
+    "blecx/AI-Agent-Framework|S3R-BE-07": {
+      "issue_number": 686,
+      "issue_url": "https://github.com/blecx/AI-Agent-Framework/issues/686",
+      "repo": "blecx/AI-Agent-Framework",
+      "repo_alias": "AI-Agent-Framework",
+      "source_file": "planning/issues/step-3.yml",
+      "source_id": "S3R-BE-07",
+      "status": "created",
+      "title": "Step 3R \u2014 Deterministic diff ordering and normalization",
+      "title_hash": "e5d8501c8b4f"
+    },
+    "blecx/AI-Agent-Framework|S3R-BE-08": {
+      "issue_number": 687,
+      "issue_url": "https://github.com/blecx/AI-Agent-Framework/issues/687",
+      "repo": "blecx/AI-Agent-Framework",
+      "repo_alias": "AI-Agent-Framework",
+      "source_file": "planning/issues/step-3.yml",
+      "source_id": "S3R-BE-08",
+      "status": "created",
+      "title": "Step 3R \u2014 Backend test-doc freshness checker script",
+      "title_hash": "b6ed726531d6"
+    },
+    "blecx/AI-Agent-Framework|S3R-BE-09": {
+      "issue_number": 688,
+      "issue_url": "https://github.com/blecx/AI-Agent-Framework/issues/688",
+      "repo": "blecx/AI-Agent-Framework",
+      "repo_alias": "AI-Agent-Framework",
+      "source_file": "planning/issues/step-3.yml",
+      "source_id": "S3R-BE-09",
+      "status": "created",
+      "title": "Step 3R \u2014 Backend CI wiring for Step 3 quality checks",
+      "title_hash": "ffc79ddb1d7c"
     },
     "blecx/AI-Agent-Framework|S4-BE-01": {
       "issue_number": 481,

--- a/planning/issues/step-3.yml
+++ b/planning/issues/step-3.yml
@@ -1,245 +1,544 @@
-# Step 3 — Hardening with strict token-budgeted issue specs.
-# Constraint: each issue body stays compact to fit free-tier execution models.
+# Step 3 (Recreated) — smaller, execution-friendly issues with strict tagging.
 
 AI-Agent-Framework:
-  - number: "S3-BE-01"
+  - number: "S3R-BE-01"
     size_estimate: "S"
-    title: "Step 3 — TUI deterministic E2E spine baseline (backend)"
+    title: "Step 3R — Establish deterministic TUI E2E fixture baseline"
     labels:
       - step:3
+      - track:step3-backend
       - tests/e2e
       - backend/tui
       - size:S
+      - priority:P1
+      - status:ready
     body: |
       ## Goal / Problem Statement
-      Add a minimal deterministic TUI E2E baseline so CI can run one stable end-to-end workflow.
+      Create deterministic fixture/setup primitives for backend TUI E2E tests to remove flaky environment variance.
 
       ## Scope
       ### In Scope
-      - Add one backbone E2E scenario under `tests/e2e/tui/`.
-      - Add deterministic helper fixture/wait utilities (no sleep-based timing).
-      - Add `tests/README.md` section for TUI E2E run instructions.
+      - Add deterministic project/workspace fixture utilities for TUI E2E tests.
+      - Remove arbitrary sleeps from fixture bootstrap paths.
+      - Provide one helper API for setup/teardown used by subsequent Step 3 tests.
       ### Out of Scope
-      - Full multi-scenario suite expansion.
-      - New product features.
+      - Full scenario implementation.
+      - CI policy changes.
       ### Dependencies
-      - Existing TUI command flows.
+      - Existing `tests/e2e/tui` structure.
 
       ## Acceptance Criteria
-      - [ ] `tests/e2e/tui/test_workflow_spine.py` exists and runs in CI.
-      - [ ] Test is deterministic across 3 consecutive local runs.
-      - [ ] `tests/README.md` includes setup + run command.
+      - [ ] Fixture helper module exists and is reusable by multiple test files.
+      - [ ] Setup/teardown is deterministic across 3 consecutive local runs.
+      - [ ] No new `sleep()` calls are introduced in fixture setup path.
 
       ## Technical Approach
-      - Create one focused workflow-spine test and shared deterministic helper.
-      - Keep fixtures local to `tests/e2e/tui/`.
+      - Introduce focused fixture helper and reuse existing test factories.
+      - Standardize temp path handling and cleanup lifecycle.
 
       ## Testing Requirements
-      - `pytest tests/e2e/tui/test_workflow_spine.py -q`
-      - `pytest tests/e2e/tui/test_workflow_spine.py -q -x`
+      - `pytest tests/e2e/tui -k fixture -q`
 
       ## Documentation Updates
-      - [ ] Update `tests/README.md` with TUI E2E baseline instructions.
+      - [ ] Add fixture usage note in `tests/README.md`.
 
       ## Cross-Repository Coordination
       None.
 
-  - number: "S3-BE-02"
+  - number: "S3R-BE-02"
     size_estimate: "S"
-    title: "Step 3 — Cross-artifact audit rule pack v1 (backend)"
+    title: "Step 3R — TUI E2E spine scenario stabilization"
     labels:
       - step:3
+      - track:step3-backend
+      - tests/e2e
+      - backend/tui
+      - size:S
+      - priority:P1
+      - status:blocked
+    body: |
+      ## Goal / Problem Statement
+      Deliver a deterministic workflow-spine E2E scenario using the new fixture baseline.
+
+      ## Scope
+      ### In Scope
+      - Implement one backbone scenario with deterministic assertions.
+      - Replace timing-sensitive waits with state-based waits.
+      - Keep the scenario single-purpose and reproducible.
+      ### Out of Scope
+      - Proposal/audit fix-cycle scenarios.
+      - Broad scenario matrix expansion.
+      ### Dependencies
+      - S3R-BE-01.
+
+      ## Acceptance Criteria
+      - [ ] One spine scenario passes 3 consecutive local runs.
+      - [ ] Scenario contains no arbitrary sleep-based waits.
+      - [ ] Failure output is actionable (clear assertion context).
+
+      ## Technical Approach
+      - Rework scenario execution with deterministic checkpoints.
+
+      ## Testing Requirements
+      - `pytest tests/e2e/tui -k workflow_spine -q`
+
+      ## Documentation Updates
+      - [ ] Document deterministic run command in `tests/README.md`.
+
+      ## Cross-Repository Coordination
+      None.
+
+  - number: "S3R-BE-03"
+    size_estimate: "S"
+    title: "Step 3R — Proposal apply/review E2E stabilization"
+    labels:
+      - step:3
+      - track:step3-backend
+      - tests/e2e
+      - backend/tui
+      - size:S
+      - priority:P1
+      - status:blocked
+    body: |
+      ## Goal / Problem Statement
+      Stabilize one proposal review/apply E2E path with deterministic state transitions.
+
+      ## Scope
+      ### In Scope
+      - Add one proposal review/apply scenario with stable checkpoints.
+      - Normalize assertions around proposal diff state.
+      - Reuse fixture baseline and avoid duplicate setup logic.
+      ### Out of Scope
+      - Conflict/multi-proposal matrix.
+      ### Dependencies
+      - S3R-BE-01.
+
+      ## Acceptance Criteria
+      - [ ] Proposal scenario passes 3 consecutive runs.
+      - [ ] Assertions verify deterministic proposal state transitions.
+      - [ ] Setup logic reuses shared fixture helper.
+
+      ## Technical Approach
+      - Isolate scenario flow into deterministic helper steps.
+
+      ## Testing Requirements
+      - `pytest tests/e2e/tui -k proposal -q`
+
+      ## Documentation Updates
+      - [ ] Add proposal scenario command to `tests/README.md`.
+
+      ## Cross-Repository Coordination
+      None.
+
+  - number: "S3R-BE-04"
+    size_estimate: "S"
+    title: "Step 3R — Audit fix-cycle E2E stabilization"
+    labels:
+      - step:3
+      - track:step3-backend
+      - tests/e2e
+      - backend/tui
+      - size:S
+      - priority:P1
+      - status:blocked
+    body: |
+      ## Goal / Problem Statement
+      Stabilize one audit->fix->re-audit E2E flow for deterministic quality feedback loops.
+
+      ## Scope
+      ### In Scope
+      - Add deterministic audit fix-cycle scenario.
+      - Verify state transition from failing audit to passing audit.
+      - Keep test surface minimal and stable.
+      ### Out of Scope
+      - Full audit rule matrix.
+      ### Dependencies
+      - S3R-BE-01.
+
+      ## Acceptance Criteria
+      - [ ] Audit fix-cycle test passes 3 consecutive runs.
+      - [ ] Scenario validates deterministic before/after audit status.
+      - [ ] No sleep-based waits in scenario.
+
+      ## Technical Approach
+      - Reuse deterministic fixture utilities and explicit state checks.
+
+      ## Testing Requirements
+      - `pytest tests/e2e/tui -k audit -q`
+
+      ## Documentation Updates
+      - [ ] Add audit fix-cycle command to `tests/README.md`.
+
+      ## Cross-Repository Coordination
+      None.
+
+  - number: "S3R-BE-05"
+    size_estimate: "S"
+    title: "Step 3R — Audit rule: cross-reference consistency"
+    labels:
+      - step:3
+      - track:step3-backend
       - backend/api/tui
       - size:S
+      - priority:P2
+      - status:blocked
     body: |
       ## Goal / Problem Statement
-      Implement a small first pack of cross-artifact audit checks with deterministic outputs.
+      Add one deterministic audit rule for cross-reference consistency across key artifacts.
 
       ## Scope
       ### In Scope
-      - Add 2-3 high-value rules (reference consistency + date consistency).
-      - Ensure deterministic error ordering/messages.
-      - Add unit tests for each new rule.
+      - Implement one cross-reference consistency rule.
+      - Add pass/fail unit tests for this rule.
+      - Ensure deterministic message ordering for this rule output.
       ### Out of Scope
-      - Full audit engine redesign.
-      - Bulk multi-project auditing.
+      - Additional rule families.
       ### Dependencies
-      - Existing audit service/rule interfaces.
+      - S3R-BE-02.
 
       ## Acceptance Criteria
-      - [ ] New rules execute in current audit flow.
-      - [ ] Rule outputs are deterministic for identical input.
-      - [ ] Unit tests cover pass/fail paths.
+      - [ ] Rule executes in current audit flow.
+      - [ ] Unit tests cover positive and negative cases.
+      - [ ] Output ordering is deterministic.
 
       ## Technical Approach
-      - Extend current audit rule registry with compact rule implementations.
-      - Normalize result sorting before return.
+      - Extend current audit rule registry with one focused rule implementation.
 
       ## Testing Requirements
-      - `pytest tests/unit -k "audit and cross" -q`
-      - `pytest tests/integration -k audit -q`
+      - `pytest tests/unit -k "audit and cross_reference" -q`
 
       ## Documentation Updates
-      - [ ] Add short rule summary to `docs/` audit documentation.
+      - [ ] Document rule behavior in audit docs.
 
       ## Cross-Repository Coordination
       None.
 
-  - number: "S3-BE-03"
+  - number: "S3R-BE-06"
     size_estimate: "S"
-    title: "Step 3 — Backend CI gate for test-doc freshness"
+    title: "Step 3R — Audit rule: date-window consistency"
     labels:
       - step:3
+      - track:step3-backend
+      - backend/api/tui
+      - size:S
+      - priority:P2
+      - status:blocked
+    body: |
+      ## Goal / Problem Statement
+      Add one deterministic audit rule validating date-window consistency.
+
+      ## Scope
+      ### In Scope
+      - Implement one date-window consistency rule.
+      - Add targeted unit tests for pass/fail behavior.
+      - Keep rule output deterministic.
+      ### Out of Scope
+      - Date normalization redesign.
+      ### Dependencies
+      - S3R-BE-02.
+
+      ## Acceptance Criteria
+      - [ ] Rule is executed within existing audit pipeline.
+      - [ ] Unit tests cover boundary conditions.
+      - [ ] Messages are deterministic for identical inputs.
+
+      ## Technical Approach
+      - Add one focused rule with stable sort key.
+
+      ## Testing Requirements
+      - `pytest tests/unit -k "audit and date" -q`
+
+      ## Documentation Updates
+      - [ ] Add date consistency rule note in docs.
+
+      ## Cross-Repository Coordination
+      None.
+
+  - number: "S3R-BE-07"
+    size_estimate: "S"
+    title: "Step 3R — Deterministic diff ordering and normalization"
+    labels:
+      - step:3
+      - track:step3-backend
+      - backend/api/tui
+      - size:S
+      - priority:P2
+      - status:blocked
+    body: |
+      ## Goal / Problem Statement
+      Remove non-deterministic diff ordering for stable proposal previews.
+
+      ## Scope
+      ### In Scope
+      - Normalize deterministic ordering in diff output.
+      - Add focused tests for deterministic output across repeated runs.
+      - Keep existing diff format stable.
+      ### Out of Scope
+      - Full diff engine redesign.
+      ### Dependencies
+      - S3R-BE-03.
+
+      ## Acceptance Criteria
+      - [ ] Identical input yields identical diff ordering.
+      - [ ] Regression tests cover deterministic ordering.
+      - [ ] Existing public diff format remains compatible.
+
+      ## Technical Approach
+      - Add stable ordering normalization at diff assembly boundary.
+
+      ## Testing Requirements
+      - `pytest tests/unit -k "diff and deterministic" -q`
+
+      ## Documentation Updates
+      - [ ] Update diff determinism note in docs.
+
+      ## Cross-Repository Coordination
+      None.
+
+  - number: "S3R-BE-08"
+    size_estimate: "S"
+    title: "Step 3R — Backend test-doc freshness checker script"
+    labels:
+      - step:3
+      - track:step3-backend
       - ci/cd
       - docs
       - size:S
+      - priority:P2
+      - status:blocked
     body: |
       ## Goal / Problem Statement
-      Prevent drift between backend test layout and `tests/README.md` by enforcing a CI gate.
+      Add a lightweight backend checker that fails when test docs drift from required sections.
 
       ## Scope
       ### In Scope
-      - Add a lightweight check script for required README sections/paths.
-      - Wire script into CI quality gates.
-      - Provide actionable failure messages.
+      - Implement one deterministic checker script for required test doc sections.
+      - Add clear remediation output.
+      - Keep checker focused on Step 3 test docs only.
       ### Out of Scope
-      - Full doc style linting platform.
-      - Cross-repo documentation checks.
+      - Full docs lint framework.
       ### Dependencies
-      - Existing backend CI workflow.
+      - S3R-BE-04.
 
       ## Acceptance Criteria
-      - [ ] CI fails when required test-doc sections are missing.
-      - [ ] CI passes when docs are aligned.
-      - [ ] Local command is documented for contributors.
+      - [ ] Checker fails on missing required sections.
+      - [ ] Checker passes on valid docs.
+      - [ ] Output includes actionable remediation.
 
       ## Technical Approach
-      - Add deterministic checker script under `scripts/`.
-      - Add focused CI step with explicit remediation text.
+      - Add small script under `scripts/` with deterministic checks.
 
       ## Testing Requirements
-      - `./.venv/bin/python scripts/<checker>.py`
-      - `pytest tests/unit -k "doc or checker" -q`
+      - `python scripts/check_test_docs_freshness.py`
+      - `pytest tests/unit -k "docs and freshness" -q`
 
       ## Documentation Updates
-      - [ ] Update `tests/README.md` and `docs/development.md` with gate usage.
+      - [ ] Document checker usage in `docs/development.md`.
+
+      ## Cross-Repository Coordination
+      None.
+
+  - number: "S3R-BE-09"
+    size_estimate: "S"
+    title: "Step 3R — Backend CI wiring for Step 3 quality checks"
+    labels:
+      - step:3
+      - track:step3-backend
+      - ci/cd
+      - size:S
+      - priority:P2
+      - status:blocked
+    body: |
+      ## Goal / Problem Statement
+      Wire Step 3 backend checks into CI with clear gate behavior.
+
+      ## Scope
+      ### In Scope
+      - Add CI step for deterministic E2E smoke and docs freshness checker.
+      - Ensure gate fails fast with actionable output.
+      - Keep CI additions minimal and bounded.
+      ### Out of Scope
+      - Full CI pipeline redesign.
+      ### Dependencies
+      - S3R-BE-08.
+
+      ## Acceptance Criteria
+      - [ ] CI runs Step 3 backend checks automatically.
+      - [ ] Failure output includes remediation guidance.
+      - [ ] No unrelated CI workflow changes are introduced.
+
+      ## Technical Approach
+      - Add focused workflow/job updates for Step 3 checks only.
+
+      ## Testing Requirements
+      - `python scripts/check_test_docs_freshness.py`
+      - `pytest tests/e2e/tui -k "workflow_spine or proposal or audit" -q`
+
+      ## Documentation Updates
+      - [ ] Add CI gate note to backend development docs.
 
       ## Cross-Repository Coordination
       None.
 
 AI-Agent-Framework-Client:
-  - number: "S3-UX-01"
+  - number: "S3R-UX-01"
     size_estimate: "S"
-    title: "Step 3 — Client E2E happy-path baseline"
+    title: "Step 3R — Client E2E deterministic fixture baseline"
     labels:
       - step:3
       - tests/e2e
       - webui/ux
       - size:S
+      - priority:P1
+      - status:ready
     body: |
       ## Goal / Problem Statement
-      Add one deterministic client E2E happy-path scenario to establish a stable baseline.
+      Introduce deterministic client E2E fixture setup for stable baseline execution.
 
       ## Scope
       ### In Scope
-      - Add one end-to-end happy-path test under `tests/e2e/`.
-      - Capture failure screenshot/log artifact.
-      - Document local/CI run command.
+      - Add one deterministic fixture/setup helper for client E2E tests.
+      - Remove arbitrary waits in fixture setup path.
+      - Keep helper scoped for Step 3 baseline scenarios.
       ### Out of Scope
-      - Full workflow matrix coverage.
+      - Full scenario matrix.
       ### Dependencies
-      - Existing client test harness.
+      - Existing client E2E test harness.
 
       ## Acceptance Criteria
-      - [ ] Baseline E2E test runs headless in CI.
-      - [ ] Failure artifacts are captured.
-      - [ ] Docs updated.
+      - [ ] Deterministic fixture helper is reusable by multiple tests.
+      - [ ] Baseline fixture passes 3 repeated runs.
+      - [ ] No sleep-based setup waits remain in new helper.
 
       ## Technical Approach
-      - Create one stable scenario with deterministic waits.
+      - Add focused fixture utility and explicit wait conditions.
 
       ## Testing Requirements
-      - `npm --prefix client run test:e2e -- --grep baseline`
+      - `npm run test:e2e -- --grep fixture`
 
       ## Documentation Updates
-      - [ ] Update client `tests/README.md`.
-
-      ## Cross-Repository Coordination
-      May require backend test fixtures alignment.
-
-  - number: "S3-UX-02"
-    size_estimate: "S"
-    title: "Step 3 — Client validation/error pattern hardening v1"
-    labels:
-      - step:3
-      - webui/ux
-      - size:S
-    body: |
-      ## Goal / Problem Statement
-      Standardize a small set of client validation/error handling patterns for consistent UX.
-
-      ## Scope
-      ### In Scope
-      - Normalize validation message rendering for one core form flow.
-      - Add network error fallback messaging for one API path.
-      - Add focused tests.
-      ### Out of Scope
-      - Whole-app validation rewrite.
-      ### Dependencies
-      - Current form/error utility modules.
-
-      ## Acceptance Criteria
-      - [ ] Selected form path has consistent validation UX.
-      - [ ] One API error path has deterministic fallback handling.
-      - [ ] Tests cover success + error scenarios.
-
-      ## Technical Approach
-      - Reuse existing utility abstractions; no new framework.
-
-      ## Testing Requirements
-      - `npm --prefix client run test -- --runInBand`
-
-      ## Documentation Updates
-      - [ ] Update usage notes in client README/docs.
+      - [ ] Add fixture usage note in client test docs.
 
       ## Cross-Repository Coordination
       None.
 
-  - number: "S3-UX-03"
+  - number: "S3R-UX-02"
     size_estimate: "S"
-    title: "Step 3 — Client CI gate for test-doc freshness"
+    title: "Step 3R — Client form validation consistency pass"
+    labels:
+      - step:3
+      - webui/ux
+      - size:S
+      - priority:P2
+      - status:blocked
+    body: |
+      ## Goal / Problem Statement
+      Standardize one key form validation path for predictable UX behavior.
+
+      ## Scope
+      ### In Scope
+      - Normalize validation display for one core form flow.
+      - Add focused unit/integration tests for this flow.
+      - Ensure deterministic validation messaging.
+      ### Out of Scope
+      - Full application-wide validation rewrite.
+      ### Dependencies
+      - S3R-UX-01.
+
+      ## Acceptance Criteria
+      - [ ] Selected form path has consistent validation behavior.
+      - [ ] Tests cover success/validation-error outcomes.
+      - [ ] Message ordering/content is deterministic.
+
+      ## Technical Approach
+      - Reuse existing client validation utilities.
+
+      ## Testing Requirements
+      - `npm run test -- --runInBand --grep validation`
+
+      ## Documentation Updates
+      - [ ] Document selected validation flow behavior.
+
+      ## Cross-Repository Coordination
+      None.
+
+  - number: "S3R-UX-03"
+    size_estimate: "S"
+    title: "Step 3R — Client API error fallback consistency"
+    labels:
+      - step:3
+      - webui/ux
+      - size:S
+      - priority:P2
+      - status:blocked
+    body: |
+      ## Goal / Problem Statement
+      Harden one client API error path with deterministic fallback handling.
+
+      ## Scope
+      ### In Scope
+      - Implement one deterministic API error fallback path.
+      - Add tests for error display and retry behavior.
+      - Keep flow scoped to one critical API interaction.
+      ### Out of Scope
+      - Global error-handling rewrite.
+      ### Dependencies
+      - S3R-UX-01.
+
+      ## Acceptance Criteria
+      - [ ] One API path has deterministic error fallback behavior.
+      - [ ] Retry/error states are covered by tests.
+      - [ ] User-facing messaging is consistent.
+
+      ## Technical Approach
+      - Reuse current error boundary + request wrappers.
+
+      ## Testing Requirements
+      - `npm run test -- --runInBand --grep error`
+
+      ## Documentation Updates
+      - [ ] Add fallback behavior note in client docs.
+
+      ## Cross-Repository Coordination
+      None.
+
+  - number: "S3R-UX-04"
+    size_estimate: "S"
+    title: "Step 3R — Client test-doc freshness CI check"
     labels:
       - step:3
       - ci/cd
       - docs
       - size:S
+      - priority:P2
+      - status:blocked
     body: |
       ## Goal / Problem Statement
-      Add a client CI guard that fails when test docs and test structure diverge.
+      Add a small client CI guard to prevent test documentation drift.
 
       ## Scope
       ### In Scope
-      - Add lightweight docs checker script.
+      - Add deterministic docs freshness checker.
       - Wire checker into client CI.
-      - Add remediation guidance in failure output.
+      - Provide clear remediation text.
       ### Out of Scope
-      - Full documentation lint framework.
+      - Full docs lint framework.
       ### Dependencies
-      - Existing client CI workflow.
+      - S3R-UX-01.
 
       ## Acceptance Criteria
-      - [ ] CI gate fails for stale/missing test-doc sections.
-      - [ ] CI gate passes when docs are current.
-      - [ ] Local command is documented.
+      - [ ] CI fails on missing/outdated required test-doc sections.
+      - [ ] CI passes when docs are aligned.
+      - [ ] Local checker command is documented.
 
       ## Technical Approach
-      - Implement deterministic checker with a small required-section contract.
+      - Implement a small required-section contract checker.
 
       ## Testing Requirements
-      - `npm --prefix client run check:docs`
+      - `npm run check:docs`
 
       ## Documentation Updates
-      - [ ] Update client `README.md` and test docs.
+      - [ ] Update client README/test docs with checker command.
 
       ## Cross-Repository Coordination
       None.

--- a/planning/step-3-complete-status.md
+++ b/planning/step-3-complete-status.md
@@ -1,263 +1,33 @@
-# Step 3: Planning Complete - Ready for Implementation
+# Step 3 (Recreated): Backlog Reset Status
 
-**Status:** ✅ **PLANNING COMPLETE** - All 6 issues ready, requirements validated, ready to start development
+**Status:** ✅ Recreated with smaller issues and explicit tags  
+**Date:** 2026-03-02
 
-**Date:** 2026-02-01  
-**Planning Duration:** 1 session  
-**Issues to Create:** 6 (3 backend + 3 client)  
-**Requirements Coverage:** 100% (6/6 requirements fully scoped)
+## What was reset
 
----
+- Old Step 3 planning artifacts were replaced with a new compact backlog definition.
+- The new spec decomposes work into smaller, execution-friendly slices.
+- Every new issue includes size + priority + status labels.
 
-## Summary
+## New issue shape
 
-Step 3 planning is **complete and ready for implementation**. All requirements have been:
+- Backend: 9 small issues (`S3R-BE-01` ... `S3R-BE-09`)
+- Client: 4 small issues (`S3R-UX-01` ... `S3R-UX-04`)
+- Total: 13 issues, mostly `size:S`, ordered by `status:ready` then `status:blocked`.
 
-1. ✅ Broken down into clear, implementable issues (M/L size)
-2. ✅ Organized for concurrent development (3 parallel phases)
-3. ✅ Documented with comprehensive acceptance criteria
-4. ✅ Validated against master plan (100% coverage)
-5. ✅ Quality-checked for completeness and accuracy
+## Tagging strategy
 
----
+- Shared: `step:3`
+- Backend track: `track:step3-backend`
+- Priority: `priority:P1`/`priority:P2`
+- Size: `size:S`
+- Execution order: `status:ready` for the first slice per track, all others `status:blocked`
 
-## All Issues Created ✅
+## Publish/Execution notes
 
-### Backend (blecx/AI-Agent-Framework)
-
-- [x] #85 - Step 3.01 — TUI-driven deterministic E2E test suite (backend)
-- [x] #92 - Step 3.02 — Enhanced cross-artifact audit rules + diff stability (backend)
-- [x] #93 - Step 3.03 — CI quality gates + documentation enforcement (backend)
-
-### Client (blecx/AI-Agent-Framework-Client)
-
-- [x] #110 - Step 3.04 — Client E2E test suite (Web UI)
-- [x] #111 - Step 3.05 — Client-side validation and error handling hardening (client)
-- [x] #112 - Step 3.06 — Client CI quality gates + documentation (client)
-
-**Total:** 6 issues = 3 backend + 3 client  
-**Status:** ✅ **ALL ISSUES CREATED** (2026-02-01)
-
----
-
-## Requirements Coverage: 100% ✅
-
-| #   | Requirement                | Issues         | Status  |
-| --- | -------------------------- | -------------- | ------- |
-| R1  | TUI E2E Test Suite         | #85 (BE)       | ✅ 100% |
-| R2  | Enhanced Audit Rules       | #92 (BE-part1) | ✅ 100% |
-| R3  | Diff Stability             | #92 (BE-part2) | ✅ 100% |
-| R4  | Client E2E Test Suite      | #110 (UX)      | ✅ 100% |
-| R5  | Client Validation & Errors | #111 (UX)      | ✅ 100% |
-| R6  | CI Quality Gates (Backend) | #93 (BE)       | ✅ 100% |
-| R6  | CI Quality Gates (Client)  | #112 (UX)      | ✅ 100% |
-
-**No gaps identified:** All quality hardening capabilities are scoped in the 6 issues.
-
----
-
-## Architecture Validation
-
-**Step 2 ↔ Step 3 Consistency:** ✅ **NO BREAKS**
-
-| Aspect           | Step 2                                           | Step 3                                         | Status        |
-| ---------------- | ------------------------------------------------ | ---------------------------------------------- | ------------- |
-| Domain Layer     | `domain/{templates,blueprints,proposals,audit}/` | No changes (test infrastructure uses existing) | ✅ Consistent |
-| Service Layer    | `services/{template,proposal,audit}/`            | Enhancements (audit rules, diff stability)     | ✅ Consistent |
-| API Layer        | `routers/{templates,proposals,artifacts,audit}/` | No new endpoints (quality hardening only)      | ✅ Consistent |
-| Testing Strategy | Unit → Integration → Basic E2E                   | **Enhanced:** Comprehensive deterministic E2E  | ✅ Enhanced   |
-| CI/CD            | Manual testing, no gates                         | **New:** CI quality gates enforcing standards  | ✅ Enhanced   |
-
-**Key principles maintained:**
-
-- Domain-Driven Design (DDD) - Test infrastructure follows DDD patterns
-- Single Responsibility Principle (SRP) - Test helpers focused on one task
-- Type Safety - Test fixtures are typed
-- No breaking changes - Step 3 enhances, doesn't replace
-
----
-
-## Implementation Plan
-
-### Phase 1: Testing Infrastructure (Weeks 1-2)
-
-**Concurrent work (2 devs):**
-
-```text
-Dev 1 (Backend):
-  Week 1: #85 part 1 (TUI automation framework, fixtures, helpers)
-  Week 2: #85 part 2 (E2E scenarios: workflow spine, proposal, audit fix)
-
-Dev 2 (Client):
-  Week 1-2: #110 (Playwright setup, page objects, full workflow E2E, visual regression)
-```
-
-**Deliverables:**
-
-- ✅ TUI E2E framework operational with 3 scenarios
-- ✅ Web UI E2E framework operational with full workflow coverage
-- ✅ Both frameworks integrated with CI (headless mode)
-- ✅ Test execution time acceptable (Backend < 5min, Client < 10min)
-
-**Success criteria:**
-
-- Tests run reliably (5 consecutive passes)
-- Documentation complete (`tests/README.md` updated)
-- CI integration working (automated execution on PRs)
-
----
-
-### Phase 2: Quality Hardening (Weeks 3-4)
-
-**Concurrent work (2 devs):**
-
-```text
-Dev 1 (Backend):
-  Week 3: #92 part 1 (9 enhanced audit rules + unit tests)
-  Week 4: #92 part 2 (Diff stability + conflict detection + property tests)
-
-Dev 2 (Client):
-  Week 3: #111 part 1 (Validation framework + real-time feedback)
-  Week 4: #111 part 2 (Error handling + accessibility + network recovery)
-```
-
-**Deliverables:**
-
-- ✅ 9 audit rules implemented and tested
-- ✅ Diff generation is deterministic (1000 iterations pass)
-- ✅ Concurrent proposals handled with conflict detection
-- ✅ Client validation matches backend schemas
-- ✅ Network errors handled gracefully with retry
-- ✅ Accessibility score ≥ 90 (Lighthouse)
-
-**Success criteria:**
-
-- All unit tests pass (80%+ coverage)
-- Integration tests cover all rule types and error scenarios
-- E2E tests validate complex workflows
-
----
-
-### Phase 3: CI Gates & Documentation (Week 5)
-
-**Concurrent work (2 devs):**
-
-```text
-Dev 1 (Backend):
-  Week 5: #93 (9 CI gates: coverage, docs, security, linting, performance)
-
-Dev 2 (Client):
-  Week 5: #112 (10 CI gates: coverage, bundle size, Lighthouse, visual regression)
-```
-
-**Deliverables:**
-
-- ✅ Backend CI configuration (`.github/workflows/ci-backend.yml`)
-- ✅ Client CI configuration (`.github/workflows/ci-client.yml`)
-- ✅ Coverage enforcement (80%+ for new code)
-- ✅ Documentation validation (fail if out of sync)
-- ✅ Security scanning (bandit, safety, npm audit)
-- ✅ Bundle size limits enforced (< 500KB gzipped)
-- ✅ Lighthouse CI integration (performance ≥ 80, accessibility ≥ 90)
-
-**Success criteria:**
-
-- CI fails appropriately for missing tests or docs
-- Clear failure messages with remediation steps
-- Fast feedback (< 10min total CI time)
-
----
-
-### Total Estimated Time: 5 weeks (with 2 devs)
-
-**Critical path:**
-
-- Phase 1 → Phase 2 → Phase 3 (sequential, but internal work is concurrent)
-- CI gates (Phase 3) depend on E2E tests (Phase 1) being operational
-
-**Resource allocation:**
-
-- 1 backend dev: BE-17 → BE-18 → BE-19
-- 1 frontend dev: UX-17 → UX-18 → UX-19
-
----
-
-## Dependency Analysis
-
-### Issue Dependencies
-
-```text
-Backend:
-  #85 (TUI E2E) - No dependencies (foundational)
-    ↓
-  #92 (Audit + Diff) - Concurrent with #85 week 2 (uses existing APIs)
-    ↓
-  #93 (CI gates) - Depends on #85 (needs tests to validate)
-
-Client:
-  #110 (Web E2E) - No dependencies (uses existing Step 2 APIs)
-    ↓
-  #111 (Validation + Errors) - Concurrent with #110 week 2 (uses existing components)
-    ↓
-  #112 (CI gates) - Depends on #110 (needs tests to validate)
-```
-
-**No cross-repo blocking:** Backend and client work streams are independent.
-
-**Concurrency opportunities:**
-
-- Phase 1: Both devs working on E2E frameworks (fully parallel)
-- Phase 2: Both devs working on quality hardening (fully parallel)
-- Phase 3: Both devs working on CI gates (fully parallel)
-
----
-
-## Quality Validation
-
-### Completeness Checklist
-
-**Requirements:**
-
-- [x] All 6 requirements have clear acceptance criteria
-- [x] All requirements mapped to specific issues
-- [x] Dependencies identified and documented
-- [x] Scope boundaries clear (in/out of Step 3)
-- [x] Validation commands provided for all requirements
-- [x] Success criteria defined (testable)
-
-**Issues (to be created):**
-
-- [x] Each issue template includes Goal, Scope, Acceptance Criteria
-- [x] Each issue has Technical Approach and Testing Requirements
-- [x] Each issue has Documentation Updates section
-- [x] Each issue has Estimated Effort (M/L)
-- [x] Each issue has appropriate Labels (step:3, backend/client, tests/e2e, ci/cd)
-
-**Architecture:**
-
-- [x] DDD principles maintained (test infrastructure follows domain patterns)
-- [x] SRP for test helpers (one responsibility per helper class)
-- [x] Type safety (typed test fixtures, no `any` types)
-- [x] Service pattern (TUI automation service, page object service)
-- [x] No breaking changes to Step 2 APIs or structure
-
-**Documentation:**
-
-- [x] STEP-3-REQUIREMENTS.md complete (26 pages, comprehensive)
-- [x] step-3-requirements-coverage.md complete (100% coverage validated)
-- [x] step-3-complete-status.md complete (this document)
-- [x] Implementation plan clear (3 phases, 5 weeks, 2 devs)
-
-**Cross-Repo Coordination:**
-
-- [x] Backend and client work streams identified
-- [x] No blocking cross-repo dependencies
-- [x] Shared standards documented (80% coverage, documentation validation)
-- [x] Coordination points identified (weekly sync, schema alignment)
-
----
-
-## Risk Assessment
+- Source of truth: `planning/issues/step-3.yml`
+- Backend publisher path: `scripts/continue-phase-3.sh` → `scripts/publish_issues.py --paths planning/issues/step-3.yml --repo blecx/AI-Agent-Framework --apply`
+- Existing open Step 3 issues from prior backlog should be closed as superseded before executing the new queue.
 
 ### Risk 1: Flaky E2E Tests
 

--- a/planning/step-3-requirements-coverage.md
+++ b/planning/step-3-requirements-coverage.md
@@ -1,263 +1,41 @@
-# Step 3: Requirements Coverage Analysis
-
-**Status:** ✅ **COMPLETE** - All Step 3 requirements fully covered by 6 issues  
-**Date:** 2026-02-01  
-**Coverage:** 100% (6/6 requirements mapped to issues)
-
----
-
-## Overview
-
-This document analyzes Step 3 requirements coverage, identifies gaps, and validates that all quality hardening capabilities are scoped in the 6 planned issues.
-
----
-
-## Requirements Coverage Matrix
-
-| Requirement                        | Step 3 Scope                                            | Issues         | Coverage | Notes                                        |
-| ---------------------------------- | ------------------------------------------------------- | -------------- | -------- | -------------------------------------------- |
-| **R1:** TUI E2E Test Suite         | Full workflow coverage, deterministic, CI-integrated    | BE-17          | ✅ 100%  | Single issue covers all TUI E2E scenarios    |
-| **R2:** Enhanced Audit Rules       | Cross-ref validation, date checks, dependency cycles    | BE-18 (part 1) | ✅ 100%  | Combined with diff stability in BE-18        |
-| **R3:** Diff Stability             | Deterministic diffs, conflict detection                 | BE-18 (part 2) | ✅ 100%  | Logical pairing with audit hardening         |
-| **R4:** Client E2E Test Suite      | Playwright/Cypress, page objects, visual regression     | UX-17          | ✅ 100%  | Single issue covers all Web UI E2E scenarios |
-| **R5:** Client Validation & Errors | Client-side validation, error handling, accessibility   | UX-18          | ✅ 100%  | Comprehensive client hardening               |
-| **R6:** CI Quality Gates (Backend) | Coverage enforcement, doc validation, security scanning | BE-19          | ✅ 100%  | Backend-specific CI gates                    |
-| **R6:** CI Quality Gates (Client)  | Bundle size, Lighthouse, visual regression, coverage    | UX-19          | ✅ 100%  | Client-specific CI gates                     |
-
-**Total:** 7 requirements mapped to 6 issues (R2 + R3 combined into BE-18)
-
----
-
-## Coverage Validation
-
-### R1: TUI E2E Test Suite (BE-17) ✅
-
-**What's covered:**
-
-- ✅ TUI automation framework (`tests/e2e/tui/` infrastructure)
-- ✅ Test data factories for all domain objects
-- ✅ Deterministic execution (no sleeps, proper awaits)
-- ✅ Workflow spine test (create project → artifacts → proposal → apply → audit)
-- ✅ Proposal workflow test (manual + AI proposals)
-- ✅ Audit fix cycle test (audit → fix → re-audit)
-- ✅ CI integration (headless, automated)
-- ✅ Documentation in `tests/README.md`
-
-**Evidence of completeness:**
-
-- Issue BE-17 acceptance criteria list all 3 mandatory E2E scenarios
-- Framework requirements include automation helpers, fixtures, CI integration
-- Test stability requirement (5 consecutive passes)
-- Performance target (< 5min execution)
-
-**Gap analysis:** ✅ No gaps - comprehensive TUI E2E coverage
-
----
-
-### R2: Enhanced Audit Rules (BE-18, part 1) ✅
-
-**What's covered:**
-
-- ✅ Cross-reference validation (RAID ↔ PMP milestones/deliverables)
-- ✅ Date consistency checks (milestone dates vs. project dates, RAID due dates)
-- ✅ Owner/actor validation (referenced users exist)
-- ✅ Dependency cycle detection (circular dependencies)
-- ✅ Completeness scoring (percentage of required fields)
-- ✅ Configurable rule sets per blueprint
-- ✅ Custom rule definition interface
-- ✅ Bulk audit (all projects)
-- ✅ Audit history tracking
-
-**Evidence of completeness:**
-
-- All 9 audit rule types explicitly listed in BE-18 scope
-- Unit tests required for each rule individually
-- Integration tests for full audit with all rules
-- E2E tests for complex cross-artifact scenarios
-
-**Gap analysis:** ✅ No gaps - comprehensive audit rule coverage
-
----
-
-### R3: Diff Stability (BE-18, part 2) ✅
-
-**What's covered:**
-
-- ✅ Standardized diff format (unified diff or structured JSON)
-- ✅ Deterministic diff generation (same changes → identical diff)
-- ✅ Whitespace/formatting consistency
-- ✅ Concurrent proposal detection
-- ✅ Conflict detection before apply
-- ✅ Diff preview accuracy (preview matches apply)
-- ✅ Line-level accuracy (exact line numbers, context lines)
-
-**Evidence of completeness:**
-
-- Issue BE-18 scope explicitly includes "Diff stability" section
-- Determinism testing (1000 iteration requirement in STEP-3-REQUIREMENTS.md)
-- Concurrent proposal handling with conflict detection
-- Property-based tests for diff determinism
-
-**Gap analysis:** ✅ No gaps - comprehensive diff stability coverage
-
-**Note:** R2 and R3 are combined in BE-18 because they're related backend service enhancements (audit and proposal services). This is efficient and maintains logical cohesion.
-
----
-
-### R4: Client E2E Test Suite (UX-17) ✅
-
-**What's covered:**
-
-- ✅ Playwright or Cypress framework in `tests/e2e/`
-- ✅ Page object model or component testing pattern
-- ✅ Full workflow test (login → project → artifacts → proposals → audit → fix)
-- ✅ Multi-artifact navigation and editing
-- ✅ Proposal diff visualization and interaction
-- ✅ Audit results interaction and navigation
-- ✅ Error state testing (network failures, API errors)
-- ✅ Visual regression testing for key screens
-- ✅ CI integration (headless mode, screenshot capture)
-
-**Evidence of completeness:**
-
-- Issue UX-17 acceptance criteria list all 3 mandatory E2E scenarios
-- Page objects defined for all major components
-- Visual regression setup included
-- Test stability requirement (5 consecutive passes)
-- Performance target (< 10min execution)
-
-**Gap analysis:** ✅ No gaps - comprehensive client E2E coverage
-
----
-
-### R5: Client Validation & Error Handling (UX-18) ✅
-
-**What's covered:**
-
-**Validation:**
-
-- ✅ Client-side validation matching backend schemas
-- ✅ Real-time validation feedback
-- ✅ Prevent invalid submissions
-- ✅ Validation error aggregation
-
-**Error Handling:**
-
-- ✅ Network error recovery (retry with exponential backoff)
-- ✅ API error response handling (user-friendly messages)
-- ✅ Optimistic updates with rollback
-- ✅ Loading states and skeletons
-- ✅ Global error boundary
-
-**UX Hardening:**
-
-- ✅ Unsaved changes warning
-- ✅ Confirmation dialogs for destructive actions
-- ✅ Keyboard navigation support
-- ✅ Accessibility improvements (ARIA, screen reader)
-- ✅ Performance optimization (lazy loading, memoization)
-
-**Evidence of completeness:**
-
-- Issue UX-18 scope breaks down into 3 subsections (validation, error handling, UX hardening)
-- All 14 acceptance criteria mapped to scope items
-- Accessibility audit requirement (Lighthouse score ≥ 90)
-- Unit, integration, and E2E tests required
-
-**Gap analysis:** ✅ No gaps - comprehensive client hardening coverage
-
----
-
-### R6: CI Quality Gates (BE-19 + UX-19) ✅
-
-**Backend CI Gates (BE-19):**
-
-- ✅ All tests pass (unit + integration + E2E)
-- ✅ Test coverage threshold (80%+ for new code)
-- ✅ No missing tests for new features (coverage diff check)
-- ✅ Documentation completeness check (`tests/README.md`)
-- ✅ API documentation (OpenAPI/Swagger) validation
-- ✅ Linting and code quality checks (black, flake8)
-- ✅ Security vulnerability scanning (bandit, safety)
-- ✅ Test execution time monitoring
-- ✅ Flaky test detection
-
-**Client CI Gates (UX-19):**
-
-- ✅ All tests pass (unit + integration + E2E)
-- ✅ Test coverage threshold (80%+ for components)
-- ✅ No missing tests for new components
-- ✅ Build succeeds without warnings
-- ✅ Bundle size limits (main bundle < 500KB gzipped)
-- ✅ Linting and formatting checks (ESLint, Prettier)
-- ✅ TypeScript strict mode (if applicable)
-- ✅ Lighthouse score thresholds (performance ≥ 80, accessibility ≥ 90)
-- ✅ No console errors in production build
-- ✅ Visual regression baseline updates
-
-**Evidence of completeness:**
-
-- Backend: 9 specific CI gates listed in BE-19
-- Client: 10 specific CI gates listed in UX-19
-- Both include documentation validation
-- Both include coverage enforcement
-- Clear failure messages with remediation steps
-
-**Gap analysis:** ✅ No gaps - comprehensive CI gate coverage for both repos
-
----
-
-## Issue Size Analysis
-
-| Issue | Size | Estimated Effort | Justification                                                                                  |
-| ----- | ---- | ---------------- | ---------------------------------------------------------------------------------------------- |
-| BE-17 | L    | 8-10 days        | TUI automation framework + 3 E2E scenarios + CI integration + documentation                    |
-| BE-18 | L    | 8-10 days        | 9 audit rules + diff stability + conflict detection + property-based tests                     |
-| BE-19 | M    | 5-6 days         | CI configuration + 9 quality gates + documentation validation                                  |
-| UX-17 | L    | 8-10 days        | Playwright/Cypress setup + page objects + 3 E2E scenarios + visual regression + CI integration |
-| UX-18 | L    | 8-10 days        | Validation framework + error handling patterns + accessibility + 14 acceptance criteria        |
-| UX-19 | M    | 5-6 days         | CI configuration + 10 quality gates + bundle analysis + Lighthouse CI                          |
-
-**Total estimated effort:** 42-52 days
-
-**With 2-3 devs working concurrently:** 5-6 weeks (accounting for coordination, code review, iterations)
-
-**Size justification:**
-
-- **L (Large):** Cross-cutting infrastructure work (E2E frameworks), complex rule systems (audit), comprehensive hardening (validation + errors)
-- **M (Medium):** Focused CI configuration work with multiple gates but less implementation complexity
-
-**Note:** Step 3 issues are intentionally larger than Step 2 issues because they address cross-cutting concerns (testing infrastructure, quality gates) rather than isolated features.
-
----
-
-## Dependency Analysis
-
-### Sequential Dependencies
-
-```
-Phase 1 (Weeks 1-2): Testing Infrastructure
-  BE-17 (TUI E2E) ←--concurrent--→ UX-17 (Client E2E)
-    ↓                                     ↓
-Phase 2 (Weeks 3-4): Quality Hardening
-  BE-18 (Audit + Diff) ←--concurrent--→ UX-18 (Validation + Errors)
-    ↓                                     ↓
-Phase 3 (Week 5): CI Gates
-  BE-19 (Backend CI) ←--concurrent--→ UX-19 (Client CI)
-```
-
-**Key dependencies:**
-
-1. **CI gates depend on E2E tests:** Cannot enforce test completeness without tests to validate
-   - BE-19 depends on BE-17 (need TUI E2E tests to gate)
-   - UX-19 depends on UX-17 (need client E2E tests to gate)
-
-2. **No cross-repo blocking:** Backend issues don't block client issues (independent work streams)
-
-3. **Concurrency opportunities:**
-   - Phase 1: 2 devs can work in parallel (BE-17 + UX-17)
-   - Phase 2: 2 devs can work in parallel (BE-18 + UX-18)
-   - Phase 3: 2 devs can work in parallel (BE-19 + UX-19)
+# Step 3 (Recreated): Requirements Coverage
+
+**Status:** ✅ Complete for recreated small-issue backlog  
+**Date:** 2026-03-02  
+**Coverage target:** 100%
+
+## Coverage Matrix
+
+| Requirement | Recreated Scope | Issues | Coverage |
+| --- | --- | --- | --- |
+| R1: Deterministic backend TUI E2E baseline | Split baseline into fixture + 3 scenario slices | S3R-BE-01, S3R-BE-02, S3R-BE-03, S3R-BE-04 | ✅ 100% |
+| R2: Cross-artifact audit hardening | Split into focused rule slices | S3R-BE-05, S3R-BE-06 | ✅ 100% |
+| R3: Diff determinism | Isolated deterministic ordering/normalization slice | S3R-BE-07 | ✅ 100% |
+| R4: Deterministic client E2E baseline | Split baseline into fixture-focused slice | S3R-UX-01 | ✅ 100% |
+| R5: Client validation + error hardening | Split into validation and API fallback slices | S3R-UX-02, S3R-UX-03 | ✅ 100% |
+| R6: CI quality gates + doc freshness | Split backend and client gates into dedicated small slices | S3R-BE-08, S3R-BE-09, S3R-UX-04 | ✅ 100% |
+
+## Why this recreation is better
+
+- Issues are smaller (`size:S`) and easier to execute/merge in sequence.
+- Ordering is explicit (`status:ready` for first slice, remaining slices `status:blocked`).
+- Priority tags are explicit for queue governance.
+- Scope isolation reduces cross-cutting churn and review risk.
+
+## Tag policy enforced in recreated set
+
+- Mandatory: `step:3`
+- Backend track: `track:step3-backend`
+- Priority: `priority:P1`/`priority:P2`
+- Size: `size:S`
+- Order status: `status:ready` / `status:blocked`
+
+## Validation commands
+
+- Spec lint: `./.venv/bin/python scripts/check_issue_specs.py --strict-sections --max-body-chars 2600 --paths planning/issues/step-3.yml`
+- Publish dry-run: `./.venv/bin/python scripts/publish_issues.py --paths planning/issues/step-3.yml`
+- Publish apply backend: `./.venv/bin/python scripts/publish_issues.py --paths planning/issues/step-3.yml --repo blecx/AI-Agent-Framework --apply`
+- Publish apply client: `./.venv/bin/python scripts/publish_issues.py --paths planning/issues/step-3.yml --repo blecx/AI-Agent-Framework-Client --apply`
 
 **Optimal team composition:** 1 backend dev + 1 frontend dev working in parallel across all 3 phases
 

--- a/scripts/continue-phase-3.sh
+++ b/scripts/continue-phase-3.sh
@@ -18,6 +18,7 @@ fi
 export WORK_ISSUE_COMPACT="${WORK_ISSUE_COMPACT:-1}"
 export WORK_ISSUE_MAX_PROMPT_CHARS="${WORK_ISSUE_MAX_PROMPT_CHARS:-3200}"
 export PYTHONUNBUFFERED="${PYTHONUNBUFFERED:-1}"
+export LLM_CONFIG_PATH="${LLM_CONFIG_PATH:-configs/llm.workflow.json}"
 
 # LLM-friendly defaults (GitHub Models can rate-limit aggressively; keep retries gentle).
 export WORK_ISSUE_LLM_MAX_ATTEMPTS="${WORK_ISSUE_LLM_MAX_ATTEMPTS:-10}"
@@ -28,9 +29,6 @@ export WORK_ISSUE_PLANNING_FALLBACK_MODEL="${WORK_ISSUE_PLANNING_FALLBACK_MODEL:
 export WORK_ISSUE_PLANNING_FALLBACK_AFTER_ATTEMPT="${WORK_ISSUE_PLANNING_FALLBACK_AFTER_ATTEMPT:-3}"
 export WORK_ISSUE_PLANNING_FALLBACK_MAX_ATTEMPTS="${WORK_ISSUE_PLANNING_FALLBACK_MAX_ATTEMPTS:-6}"
 export WORK_ISSUE_PLANNING_FALLBACK_PROMPT_CHARS="${WORK_ISSUE_PLANNING_FALLBACK_PROMPT_CHARS:-1400}"
-
-# Unbuffered Python output helps long-running loops show progress promptly.
-export PYTHONUNBUFFERED="${PYTHONUNBUFFERED:-1}"
 
 # GitHub Models can enforce burst/secondary throttles even at low average RPS.
 # Default to a conservative outbound LLM pace for this long-running loop.
@@ -222,6 +220,7 @@ echo "📝 Logging to: $LOG_FILE"
 exec > >(tee -a "$LOG_FILE") 2>&1
 
 count=0
+last_issue=""
 
 while true; do
   issue=""
@@ -238,6 +237,12 @@ while true; do
     echo "No open backend step:3 issues available; stopping phase-3 loop."
     break
   fi
+
+  if [[ "$DRY_RUN" == "1" && "$issue" == "$last_issue" ]]; then
+    echo "Dry-run selected the same issue (#$issue) again; stopping to avoid duplicate preview output."
+    break
+  fi
+  last_issue="$issue"
 
   echo "============================================================"
   echo "/continue-phase-3 :: Processing Backend Issue #$issue"


### PR DESCRIPTION
## Summary
- recreate Step 3 planning backlog into smaller tagged slices
- refresh Step 3 status/coverage docs to reflect recreated backlog
- harden `continue-phase-3.sh` with explicit workflow config default and dry-run duplicate guard

## Validation
- `./.venv/bin/python scripts/check_issue_specs.py --strict-sections --max-body-chars 2600 --paths planning/issues/step-3.yml`
- `./scripts/continue-phase-3.sh --dry-run --max-issues 25`

Fixes #689
