### PR TITLE
fix(e2e): fixture helper slice 3 – final validation (#695)

### DIFF
--- a/tests/e2e/tui/README.md
+++ b/tests/e2e/tui/README.md
@@ -15,7 +15,8 @@ This test suite validates complete workflows using the TUI CLI:
 ```
 tests/e2e/tui/
 ├── conftest.py                     # Pytest fixtures (backend server, TUI automation, tui_workspace)
-├── helpers.py                      # Deterministic fixture helper utilities
+├── fixture_helper.py               # Public fixture-helper API (canonical entry-point, re-exports helpers)
+├── helpers.py                      # Deterministic fixture helper utilities (implementation)
 ├── test_fixture_baseline.py        # Fixture infrastructure smoke tests
 ├── test_workflow_spine.py          # Core workflow scenarios
 ├── test_proposal_workflow.py       # Proposal lifecycle tests
@@ -24,7 +25,8 @@ tests/e2e/tui/
 
 Supporting infrastructure:
 
-- `tests/e2e/tui/helpers.py` — deterministic workspace setup/teardown, port reservation, server lifecycle
+- `tests/e2e/tui/fixture_helper.py` — **canonical public API** for fixture helpers; import from here for stable, long-lived imports
+- `tests/e2e/tui/helpers.py` — implementation: workspace setup/teardown, port reservation, server lifecycle
 - `tests/helpers/tui_automation.py` — TUI command execution service
 - `tests/fixtures/factories.py` — Test data builders (Project, Artifact, Proposal, RAID)
 

--- a/tests/e2e/tui/fixture_helper.py
+++ b/tests/e2e/tui/fixture_helper.py
@@ -1,0 +1,37 @@
+"""Public fixture-helper API for TUI E2E tests.
+
+This module is the canonical entry-point referenced by issue #680.
+It re-exports all deterministic helper utilities from :mod:`e2e.tui.helpers`
+so that test code can import from a single, stable location::
+
+    from e2e.tui.fixture_helper import build_tui_workspace, reset_tui_workspace
+
+All symbols remain available via :mod:`e2e.tui.helpers` for backward
+compatibility.
+"""
+
+from __future__ import annotations
+
+from e2e.tui.helpers import (  # noqa: F401  (re-exported public API)
+    TuiE2EWorkspace,
+    build_tui_workspace,
+    reset_tui_workspace,
+    reserve_local_port,
+    resolve_python_executable,
+    start_backend_server,
+    stop_backend_server,
+    wait_for_http_ok,
+    write_json,
+)
+
+__all__ = [
+    "TuiE2EWorkspace",
+    "build_tui_workspace",
+    "reset_tui_workspace",
+    "reserve_local_port",
+    "resolve_python_executable",
+    "start_backend_server",
+    "stop_backend_server",
+    "wait_for_http_ok",
+    "write_json",
+]

--- a/tests/e2e/tui/test_fixture_baseline.py
+++ b/tests/e2e/tui/test_fixture_baseline.py
@@ -84,3 +84,41 @@ def test_tui_workspace_artifact_and_workflow_paths(tui_workspace):
     assert pmp_path.name == "pmp.json"
     assert raid_path.name == "raid.json"
     assert workflow_path.name == "state.json"
+
+
+@pytest.mark.tui
+def test_fixture_helper_module_exports_public_api():
+    """fixture_helper.py must export the canonical public API (issue #695)."""
+    import e2e.tui.fixture_helper as fh
+
+    expected = [
+        "TuiE2EWorkspace",
+        "build_tui_workspace",
+        "reset_tui_workspace",
+        "reserve_local_port",
+        "resolve_python_executable",
+        "start_backend_server",
+        "stop_backend_server",
+        "wait_for_http_ok",
+        "write_json",
+    ]
+    for name in expected:
+        assert hasattr(fh, name), f"fixture_helper is missing public symbol: {name}"
+
+
+@pytest.mark.tui
+def test_fixture_helper_symbols_identical_to_helpers():
+    """Symbols exported by fixture_helper must be the same objects as in helpers."""
+    import e2e.tui.helpers as helpers_mod
+    import e2e.tui.fixture_helper as fh
+
+    shared = [
+        "build_tui_workspace",
+        "reset_tui_workspace",
+        "wait_for_http_ok",
+        "write_json",
+    ]
+    for name in shared:
+        assert getattr(fh, name) is getattr(helpers_mod, name), (
+            f"{name} in fixture_helper must be the same object as in helpers"
+        )


### PR DESCRIPTION
Fixes: #695

## Goal
Final slice of #680 fixture helper work — create `tests/e2e/tui/fixture_helper.py` as the canonical public module originally specified in the issue.

## Changes
- **`tests/e2e/tui/fixture_helper.py`** (new): public re-export API for all helper symbols from `helpers.py`; stable import location for test code
- **`tests/e2e/tui/test_fixture_baseline.py`**: added 2 tests — `test_fixture_helper_module_exports_public_api` and `test_fixture_helper_symbols_identical_to_helpers`
- **`tests/e2e/tui/README.md`**: updated architecture diagram and supporting infrastructure section to document `fixture_helper.py`

## Validation
- [x] `pytest tests/e2e/ -q --tb=short` → 36 passed, 1 skipped (was 34 before slice 3; +2 new tests)
- [x] `projectDocs/` not committed
- [x] `configs/llm.json` not committed

## Slices summary
| Slice | PR | Description |
|---|---|---|
| 1 | #696 | `helpers.py`, `conftest.py`, `test_fixture_baseline.py`, migrated `test_audit_fix_cycle.py` |
| 2 | #697 | 4 helper utility tests, README update |
| 3 | this PR | `fixture_helper.py` public API module + import validation tests |
