### PR TITLE
feat(scripts): test-doc freshness checker (#687)

### DIFF
--- a/scripts/check_test_docs_freshness.py
+++ b/scripts/check_test_docs_freshness.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+check_test_docs_freshness.py — Step 3R backend test-doc freshness checker.
+
+Scans Step 3 test documentation files and verifies that required sections
+are present. Exits non-zero with actionable remediation messages when any
+required section is missing.
+
+Usage:
+    .venv/bin/python scripts/check_test_docs_freshness.py
+"""
+
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Configuration: file → required ## headings (exact, case-sensitive)
+# ---------------------------------------------------------------------------
+REQUIRED_SECTIONS: dict[str, list[str]] = {
+    "tests/e2e/tui/README.md": [
+        "## Architecture",
+        "## Fixtures",
+        "## Running Tests",
+    ],
+    "tests/README.md": [
+        "## Running tests locally",
+        "## TUI E2E notes",
+    ],
+}
+
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
+
+
+def extract_headings(text: str) -> list[str]:
+    """Return a sorted list of all Markdown headings found in *text*."""
+    return sorted(f"{m.group(1)} {m.group(2)}" for m in _HEADING_RE.finditer(text))
+
+
+def check_file(repo_root: Path, rel_path: str, required: list[str]) -> list[str]:
+    """
+    Check one doc file for required sections.
+
+    Returns a list of missing-section error strings (empty = all good).
+    """
+    abs_path = repo_root / rel_path
+    errors: list[str] = []
+
+    if not abs_path.exists():
+        errors.append(
+            f"  MISSING FILE  {rel_path}\n"
+            f"    → Create the file and add the required sections."
+        )
+        return errors
+
+    text = abs_path.read_text(encoding="utf-8")
+    present = set(extract_headings(text))
+
+    for section in sorted(required):
+        # Match by exact string
+        if section not in present:
+            errors.append(
+                f"  MISSING SECTION  \"{section}\"  in  {rel_path}\n"
+                f"    → Add a `{section}` heading to {rel_path}."
+            )
+
+    return errors
+
+
+def main() -> int:
+    """Run all checks. Returns 0 on success, 1 on any failure."""
+    repo_root = Path(__file__).resolve().parent.parent
+
+    all_errors: list[str] = []
+
+    for rel_path in sorted(REQUIRED_SECTIONS):
+        required = REQUIRED_SECTIONS[rel_path]
+        errors = check_file(repo_root, rel_path, required)
+        all_errors.extend(errors)
+
+    if all_errors:
+        print("❌ Test-doc freshness check FAILED\n", file=sys.stderr)
+        for err in all_errors:
+            print(err, file=sys.stderr)
+        print(
+            "\nPlease update the listed files to include the missing sections.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("✅ Test-doc freshness check passed — all required sections present.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_check_test_docs_freshness.py
+++ b/tests/unit/test_check_test_docs_freshness.py
@@ -1,0 +1,130 @@
+"""
+tests/unit/test_check_test_docs_freshness.py
+
+Unit tests for scripts/check_test_docs_freshness.py freshness checker.
+Covers: extract_headings, check_file, and end-to-end main() behaviour.
+"""
+
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# Ensure the scripts directory is on the path so we can import the module.
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from check_test_docs_freshness import (  # noqa: E402
+    REQUIRED_SECTIONS,
+    check_file,
+    extract_headings,
+    main,
+)
+
+
+# ---------------------------------------------------------------------------
+# extract_headings
+# ---------------------------------------------------------------------------
+
+class TestExtractHeadings:
+    def test_finds_h2_headings(self):
+        text = "## Architecture\n## Fixtures\n"
+        result = extract_headings(text)
+        assert "## Architecture" in result
+        assert "## Fixtures" in result
+
+    def test_finds_mixed_levels(self):
+        text = "# Title\n## Section\n### Sub\n"
+        result = extract_headings(text)
+        assert "# Title" in result
+        assert "## Section" in result
+        assert "### Sub" in result
+
+    def test_returns_sorted(self):
+        text = "## Zebra\n## Apple\n## Mango\n"
+        result = extract_headings(text)
+        assert result == sorted(result)
+
+    def test_empty_text(self):
+        assert extract_headings("") == []
+
+    def test_ignores_inline_hashes(self):
+        text = "Some text with # in the middle\n"
+        assert extract_headings(text) == []
+
+
+# ---------------------------------------------------------------------------
+# check_file
+# ---------------------------------------------------------------------------
+
+class TestCheckFile:
+    def test_all_sections_present(self, tmp_path):
+        doc = tmp_path / "tests" / "e2e" / "tui" / "README.md"
+        doc.parent.mkdir(parents=True)
+        doc.write_text(
+            textwrap.dedent("""\
+                ## Architecture
+                some content
+
+                ## Fixtures
+                some content
+
+                ## Running Tests
+                some content
+            """),
+            encoding="utf-8",
+        )
+        errors = check_file(tmp_path, "tests/e2e/tui/README.md", ["## Architecture", "## Fixtures", "## Running Tests"])
+        assert errors == []
+
+    def test_missing_section_reported(self, tmp_path):
+        doc = tmp_path / "tests" / "e2e" / "tui" / "README.md"
+        doc.parent.mkdir(parents=True)
+        doc.write_text("## Architecture\n## Fixtures\n", encoding="utf-8")
+        errors = check_file(tmp_path, "tests/e2e/tui/README.md", ["## Architecture", "## Fixtures", "## Running Tests"])
+        assert len(errors) == 1
+        assert "## Running Tests" in errors[0]
+        assert "tests/e2e/tui/README.md" in errors[0]
+
+    def test_missing_file_reported(self, tmp_path):
+        errors = check_file(tmp_path, "tests/nonexistent/README.md", ["## Foo"])
+        assert len(errors) == 1
+        assert "MISSING FILE" in errors[0]
+
+    def test_multiple_missing_sections(self, tmp_path):
+        doc = tmp_path / "tests" / "README.md"
+        doc.parent.mkdir(parents=True)
+        doc.write_text("# Just a title\n", encoding="utf-8")
+        errors = check_file(tmp_path, "tests/README.md", ["## Running tests locally", "## TUI E2E notes"])
+        assert len(errors) == 2
+
+    def test_errors_sorted_by_section(self, tmp_path):
+        doc = tmp_path / "tests" / "README.md"
+        doc.parent.mkdir(parents=True)
+        doc.write_text("# Title\n", encoding="utf-8")
+        required = ["## Zebra", "## Apple", "## Mango"]
+        errors = check_file(tmp_path, "tests/README.md", required)
+        # Errors should mention sections in sorted order
+        sections_in_errors = [e.split('"')[1] for e in errors]
+        assert sections_in_errors == sorted(sections_in_errors)
+
+
+# ---------------------------------------------------------------------------
+# main() integration
+# ---------------------------------------------------------------------------
+
+class TestMainIntegration:
+    """Run main() against the actual repo docs — they must pass."""
+
+    def test_main_passes_on_current_docs(self, capsys):
+        """Current repo docs contain all required sections → exit 0."""
+        result = main()
+        assert result == 0
+
+    def test_required_sections_config_non_empty(self):
+        assert len(REQUIRED_SECTIONS) >= 2
+
+    def test_each_file_has_required_sections(self):
+        for path, sections in REQUIRED_SECTIONS.items():
+            assert len(sections) >= 1, f"{path} has no required sections defined"


### PR DESCRIPTION
Fixes: #687

## Goal
Lightweight checker that fails when test docs drift from required sections.

## Changes
- `scripts/check_test_docs_freshness.py` — standalone stdlib-only script that scans `tests/e2e/tui/README.md` and `tests/README.md` for required `##` headings, outputs actionable remediation, and exits non-zero on any missing section
- `tests/unit/test_check_test_docs_freshness.py` — 13 unit tests covering `extract_headings`, `check_file`, and `main()` integration

## Validation
- [x] checker passes on current docs: `.venv/bin/python scripts/check_test_docs_freshness.py` → exit 0
- [x] unit tests pass: `pytest tests/unit/test_check_test_docs_freshness.py -q` → 13 passed

## Repo Hygiene
- [x] projectDocs/ not committed
- [x] configs/llm.json not committed
